### PR TITLE
feat: per-cycle VIC rendering tier

### DIFF
--- a/C64.py
+++ b/C64.py
@@ -496,7 +496,8 @@ def main():
             "charset/bank swaps mid-frame) for text/bitmap/MCM/ECM modes. "
             "`per-cycle`: one VIC/CIA2 sample per emulated cycle in the 320×200 window "
             "(requires `--vic-emulation accurate-python` or it is forced automatically; "
-            "see docs/per_cycle_vic.md). Bitmap modes fall back to per-frame latch for now. "
+            "see docs/per_cycle_vic.md). Text and bitmap modes use that grid; sprites still "
+            "latch once per frame. "
             "See docs/DEBUGGING.md."
         ),
     )

--- a/C64.py
+++ b/C64.py
@@ -495,9 +495,10 @@ def main():
             "per content row — handles vertical split screens (HUD + playfield, color bars, "
             "charset/bank swaps mid-frame) for text/bitmap/MCM/ECM modes. "
             "`per-cycle`: one VIC/CIA2 sample per emulated cycle in the 320×200 window "
-            "(requires `--vic-emulation accurate-python` or it is forced automatically; "
-            "see docs/per_cycle_vic.md). Text, bitmap, and sprites use that grid (sprites "
-            "per character column; not cycle-accurate DMA timing). "
+            "(see docs/per_cycle_vic.md). With the optional `c64py_rust_core` extension, "
+            "uses `accurate-rust` VIC + Rust sampling and compositing by default "
+            "(set `C64PY_RUST_PER_CYCLE=0` or omit the extension to force `accurate-python`). "
+            "Text, bitmap, and sprites use that grid (sprites per character column). "
             "See docs/DEBUGGING.md."
         ),
     )
@@ -509,8 +510,8 @@ def main():
             "(overrides TOML defaults for those two). Drive tier stays "
             "[emulation] disk_emulation (set in c64py.toml or via the standalone "
             "c1541_emulator --emulation). If you also select `--video-rendering per-cycle` "
-            "(from CLI or TOML), VIC stays on the Python cycle path (`accurate-python`) so "
-            "per-cycle sampling can run."
+            "(from CLI or TOML), VIC uses `accurate-rust` when the Rust core is built "
+            "(otherwise `accurate-python`)."
         ),
     )
     ap.add_argument(
@@ -754,18 +755,37 @@ def main():
     if args.video_rendering in _VIDEO_RENDERING_ALIASES:
         args.video_rendering = _VIDEO_RENDERING_ALIASES[args.video_rendering]
 
-    # Master "max accuracy" flag — per-cycle video keeps Python VIC stepping (see below).
+    def _rust_ext_cli_available() -> bool:
+        try:
+            from . import _core
+            return bool(_core.is_available)
+        except ImportError:
+            return False
+
+    rust_per_cycle_ok = _rust_ext_cli_available() and os.environ.get(
+        "C64PY_RUST_PER_CYCLE", "1"
+    ).strip().lower() not in ("0", "no", "false", "python", "off")
+
+    # Master "max accuracy" flag — per-cycle video prefers Rust hybrid VIC when the extension is built.
     if args.accurate:
         if args.video_rendering != "per-cycle":
             args.video_rendering = "per-raster"
             args.vic_emulation = "accurate-rust"
         else:
-            args.vic_emulation = "accurate-python"
-            print(
-                "Note: --accurate with --video-rendering per-cycle uses accurate-python VIC "
-                "(per-cycle sampling requires the Python cycle engine).",
-                file=sys.stderr,
-            )
+            if rust_per_cycle_ok:
+                args.vic_emulation = "accurate-rust"
+                print(
+                    "Note: --accurate with --video-rendering per-cycle uses accurate-rust VIC "
+                    "with Rust per-cycle grid sampling when c64py_rust_core is built.",
+                    file=sys.stderr,
+                )
+            else:
+                args.vic_emulation = "accurate-python"
+                print(
+                    "Note: --accurate with --video-rendering per-cycle uses accurate-python VIC "
+                    "(install c64py_rust_core for faster Rust sampling).",
+                    file=sys.stderr,
+                )
 
     if args.accurate_vic:
         if args.vic_emulation != "accurate-python":
@@ -778,13 +798,23 @@ def main():
     else:
         vic_emulation = args.vic_emulation
 
-    if args.video_rendering == "per-cycle" and vic_emulation != "accurate-python":
-        print(
-            f"Note: --video-rendering per-cycle requires accurate-python VIC for sampling "
-            f"(was {vic_emulation!r}); switching to accurate-python.",
-            file=sys.stderr,
-        )
-        vic_emulation = "accurate-python"
+    if args.video_rendering == "per-cycle":
+        if rust_per_cycle_ok and vic_emulation != "accurate-python":
+            if vic_emulation == "fast":
+                print(
+                    "Note: --video-rendering per-cycle with Rust sampling upgrades "
+                    "`--vic-emulation fast` to accurate-rust.",
+                    file=sys.stderr,
+                )
+            vic_emulation = "accurate-rust"
+        elif not rust_per_cycle_ok and vic_emulation != "accurate-python":
+            print(
+                "Note: --video-rendering per-cycle needs accurate-python VIC for sampling "
+                f"when the Rust extension is missing or disabled (was {vic_emulation!r}); "
+                "switching to accurate-python.",
+                file=sys.stderr,
+            )
+            vic_emulation = "accurate-python"
 
     has_inject_src = bool(args.debug_inject_map or args.debug_inject_file)
     if args.debug_inject_at_cycle is not None and not has_inject_src:

--- a/C64.py
+++ b/C64.py
@@ -496,8 +496,8 @@ def main():
             "charset/bank swaps mid-frame) for text/bitmap/MCM/ECM modes. "
             "`per-cycle`: one VIC/CIA2 sample per emulated cycle in the 320×200 window "
             "(requires `--vic-emulation accurate-python` or it is forced automatically; "
-            "see docs/per_cycle_vic.md). Text and bitmap modes use that grid; sprites still "
-            "latch once per frame. "
+            "see docs/per_cycle_vic.md). Text, bitmap, and sprites use that grid (sprites "
+            "per character column; not cycle-accurate DMA timing). "
             "See docs/DEBUGGING.md."
         ),
     )

--- a/C64.py
+++ b/C64.py
@@ -494,8 +494,9 @@ def main():
             "`per-raster` (aka `accurate`): one VIC/CIA2 sample per raster line, dispatched "
             "per content row — handles vertical split screens (HUD + playfield, color bars, "
             "charset/bank swaps mid-frame) for text/bitmap/MCM/ECM modes. "
-            "`per-cycle`: not yet implemented; currently falls back to `per-raster` "
-            "(see docs/per_cycle_vic.md). "
+            "`per-cycle`: one VIC/CIA2 sample per emulated cycle in the 320×200 window "
+            "(requires `--vic-emulation accurate-python` or it is forced automatically; "
+            "see docs/per_cycle_vic.md). Bitmap modes fall back to per-frame latch for now. "
             "See docs/DEBUGGING.md."
         ),
     )
@@ -506,9 +507,9 @@ def main():
             "Shortcut: set --video-rendering per-raster and --vic-emulation accurate-rust "
             "(overrides TOML defaults for those two). Drive tier stays "
             "[emulation] disk_emulation (set in c64py.toml or via the standalone "
-            "c1541_emulator --emulation). When per-cycle video exists, pass "
-            "--video-rendering per-cycle after --accurate to opt in (currently still maps "
-            "to per-raster with a one-line stderr note)."
+            "c1541_emulator --emulation). If you also select `--video-rendering per-cycle` "
+            "(from CLI or TOML), VIC stays on the Python cycle path (`accurate-python`) so "
+            "per-cycle sampling can run."
         ),
     )
     ap.add_argument(
@@ -752,18 +753,18 @@ def main():
     if args.video_rendering in _VIDEO_RENDERING_ALIASES:
         args.video_rendering = _VIDEO_RENDERING_ALIASES[args.video_rendering]
 
-    # Master "max accuracy" flag — must run as its own block (not tied to per-cycle).
+    # Master "max accuracy" flag — per-cycle video keeps Python VIC stepping (see below).
     if args.accurate:
-        args.video_rendering = "per-raster"
-        args.vic_emulation = "accurate-rust"
-
-    if args.video_rendering == "per-cycle":
-        print(
-            "Note: --video-rendering per-cycle is not implemented yet; using per-raster. "
-            "See docs/per_cycle_vic.md.",
-            file=sys.stderr,
-        )
-        args.video_rendering = "per-raster"
+        if args.video_rendering != "per-cycle":
+            args.video_rendering = "per-raster"
+            args.vic_emulation = "accurate-rust"
+        else:
+            args.vic_emulation = "accurate-python"
+            print(
+                "Note: --accurate with --video-rendering per-cycle uses accurate-python VIC "
+                "(per-cycle sampling requires the Python cycle engine).",
+                file=sys.stderr,
+            )
 
     if args.accurate_vic:
         if args.vic_emulation != "accurate-python":
@@ -775,6 +776,14 @@ def main():
         vic_emulation = "accurate-python"
     else:
         vic_emulation = args.vic_emulation
+
+    if args.video_rendering == "per-cycle" and vic_emulation != "accurate-python":
+        print(
+            f"Note: --video-rendering per-cycle requires accurate-python VIC for sampling "
+            f"(was {vic_emulation!r}); switching to accurate-python.",
+            file=sys.stderr,
+        )
+        vic_emulation = "accurate-python"
 
     has_inject_src = bool(args.debug_inject_map or args.debug_inject_file)
     if args.debug_inject_at_cycle is not None and not has_inject_src:
@@ -1104,10 +1113,17 @@ def main():
 
             if args.video_rendering == "per-raster":
                 emu.memory.beam_render_enabled = True
+                emu.memory.per_cycle_render_enabled = False
                 emu.memory.ensure_beam_buffers()
                 emu.memory.prime_beam_snapshots_from_current_vic()
+            elif args.video_rendering == "per-cycle":
+                emu.memory.beam_render_enabled = False
+                emu.memory.per_cycle_render_enabled = True
+                emu.memory.ensure_per_cycle_buffers()
+                emu.memory.prime_per_cycle_snapshots_from_current_vic()
             else:
                 emu.memory.beam_render_enabled = False
+                emu.memory.per_cycle_render_enabled = False
         except Exception as e:
             # Ensure UI is not left running, then show a clear error.
             try:

--- a/C64.py
+++ b/C64.py
@@ -756,11 +756,16 @@ def main():
         args.video_rendering = _VIDEO_RENDERING_ALIASES[args.video_rendering]
 
     def _rust_ext_cli_available() -> bool:
+        # Match _check_rust_core_available / _warn_if_rust_fast_core_unavailable: when C64.py is
+        # run as a script (``python C64.py``), ``from . import _core`` fails; use ``c64py``.
         try:
             from . import _core
-            return bool(_core.is_available)
         except ImportError:
-            return False
+            try:
+                from c64py import _core
+            except ImportError:
+                return False
+        return bool(_core.is_available)
 
     rust_per_cycle_ok = _rust_ext_cli_available() and os.environ.get(
         "C64PY_RUST_PER_CYCLE", "1"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Run with graphics window:
 c64py program.prg --interface graphics --graphics-scale 3
 ```
 
-Per-scanline effects (FLI, sub-row splits): use `--video-rendering per-raster` or `--video-rendering per-cycle` with `--vic-emulation accurate-python` (forced automatically when needed; text + bitmap scanlines from the sample grid — sprites still frame-latch; see `docs/per_cycle_vic.md`).
+Per-scanline effects (FLI, sub-row splits): use `--video-rendering per-raster` or `--video-rendering per-cycle` with `--vic-emulation accurate-python` (forced automatically when needed; text + bitmap + sprites from the sample grid — sprites per 8-pixel column, not full DMA timing; see `docs/per_cycle_vic.md`).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Run with graphics window:
 c64py program.prg --interface graphics --graphics-scale 3
 ```
 
+Per-scanline effects (FLI, sub-row splits): use `--video-rendering per-raster` (default in many setups) or `--video-rendering per-cycle` with `--vic-emulation accurate-python` (forced automatically when needed; see `docs/per_cycle_vic.md`).
+
 ## Configuration
 
 c64py reads an optional TOML config file so you don't have to retype CLI

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Run with graphics window:
 c64py program.prg --interface graphics --graphics-scale 3
 ```
 
-Per-scanline effects (FLI, sub-row splits): use `--video-rendering per-raster` (default in many setups) or `--video-rendering per-cycle` with `--vic-emulation accurate-python` (forced automatically when needed; see `docs/per_cycle_vic.md`).
+Per-scanline effects (FLI, sub-row splits): use `--video-rendering per-raster` or `--video-rendering per-cycle` with `--vic-emulation accurate-python` (forced automatically when needed; text + bitmap scanlines from the sample grid — sprites still frame-latch; see `docs/per_cycle_vic.md`).
 
 ## Configuration
 

--- a/_core.py
+++ b/_core.py
@@ -9,11 +9,14 @@ If the extension is missing, ``is_available`` is False and callers keep using
 the pure-Python ``CPU6502.step`` loop instead of batched Rust execution when the
 emulator would otherwise use it: ``--vic-emulation fast`` and ``accurate-rust``.
 ``accurate-python`` always steps in Python with cycle-accurate VIC in Python and
-never uses this batch path, with or without the extension.
+never uses this batch path. With ``--video-rendering per-cycle`` and a built
+``c64py_rust_core``, ``--vic-emulation accurate-rust`` can use the same batch path
+while filling per-cycle VIC/CIA2 flat buffers from the Rust hybrid VIC.
 """
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
@@ -150,6 +153,31 @@ def run_fast_batch(
             bc_ba = cf
     beam_rust = bool(beam_enabled and beam_n > 0 and bv_ba is not None and bc_ba is not None)
 
+    def _want_rust_per_cycle_capture() -> bool:
+        v = os.environ.get("C64PY_RUST_PER_CYCLE", "1").strip().lower()
+        return v not in ("0", "no", "false", "python", "off")
+
+    per_cycle_cap = (
+        bool(getattr(memory, "per_cycle_render_enabled", False))
+        and bool(hybrid_vic_pal)
+        and _want_rust_per_cycle_capture()
+    )
+    pvc_ba: Optional[bytearray] = None
+    pcc_ba: Optional[bytearray] = None
+    if per_cycle_cap:
+        memory.ensure_per_cycle_buffers()
+        pvf = getattr(memory, "per_cycle_vic_flat", None)
+        pcf = getattr(memory, "per_cycle_cia2_flat", None)
+        if (
+            pvf is not None
+            and pcf is not None
+            and len(pvf) == 512000
+            and len(pcf) == 8000
+        ):
+            pvc_ba = pvf
+            pcc_ba = pcf
+    per_cycle_rust = bool(per_cycle_cap and pvc_ba is not None and pcc_ba is not None)
+
     t = _rust.run_fast_batch_py(
         ram,
         max_instructions,
@@ -226,6 +254,9 @@ def run_fast_batch(
         beam_n if beam_rust else 0,
         bv_ba if beam_rust else None,
         bc_ba if beam_rust else None,
+        per_cycle_rust,
+        pvc_ba if per_cycle_rust else None,
+        pcc_ba if per_cycle_rust else None,
         trace_path,
     )
     (
@@ -354,3 +385,54 @@ def run_fast_batch(
     if beam_rust and beam_n > 0 and getattr(memory, "beam_vic_flat", None) is not None:
         memory.beam_snapshots_primed = True
     return ins, cyc, opc, oa, ox, oy, osp, op, ocycles, ostopped
+
+
+def composite_per_cycle_frame(
+    memory: "MemoryMap",
+    palette_rgb48: bytes,
+    rgb_out: bytearray,
+    *,
+    video_standard: str,
+    native_width: int,
+    native_height: int,
+    screen_left: int,
+    screen_top: int,
+    screen_width: int,
+    screen_height: int,
+    border_px: int,
+    skip_sprites: bool = False,
+) -> None:
+    """Fill *rgb_out* (packed RGB888, row-major) using the Rust per-cycle compositor."""
+    if not _rust:
+        raise RuntimeError("c64py_rust_core is not built/importable")
+    flat = getattr(memory, "per_cycle_vic_flat", None)
+    cia = getattr(memory, "per_cycle_cia2_flat", None)
+    if flat is None or cia is None or len(flat) != 512000 or len(cia) != 8000:
+        raise ValueError("per_cycle flat buffers must be allocated (512000 + 8000 bytes)")
+    ram = memory.ram
+    if not isinstance(ram, bytearray):
+        raise TypeError("memory.ram must be a bytearray")
+    if len(palette_rgb48) != 48:
+        raise ValueError("palette_rgb48 must be exactly 48 bytes")
+    vs = video_standard if video_standard in ("pal", "ntsc") else "pal"
+    cr = memory.char_rom
+    cr_py = None if not cr else bytes(cr)
+    _rust.composite_per_cycle_frame_py(
+        ram,
+        flat,
+        cia,
+        cr_py,
+        vs,
+        palette_rgb48,
+        rgb_out,
+        int(native_width),
+        int(native_height),
+        int(screen_left),
+        int(screen_top),
+        int(screen_width),
+        int(screen_height),
+        int(border_px),
+        bool(skip_sprites),
+        bytes(memory._vic_regs[:64]),
+        int(memory.cia2_pra) & 0xFF,
+    )

--- a/config.py
+++ b/config.py
@@ -39,9 +39,9 @@ else:  # pragma: no cover - exercised on 3.9/3.10 only
 # names; the mapping to CLI flags lives in ``C64.py`` (CONFIG_TO_CLI).
 DEFAULT_CONFIG: Dict[str, Any] = {
     "video": {
-        # "per-frame" | "per-raster" | "per-cycle" (CLI: per-cycle falls back to per-raster). Aliases
-        # "fast"/"accurate" are accepted on the CLI for backwards compat
-        # but normalised before reaching this config.
+        # "per-frame" | "per-raster" | "per-cycle" (per-cycle uses the Python VIC cycle path;
+        # see docs/per_cycle_vic.md). Aliases "fast"/"accurate" are accepted on the CLI for
+        # backwards compat but normalised before reaching this config.
         "rendering": "per-frame",
         "standard": "pal",
         "scale": 2,

--- a/cpu.py
+++ b/cpu.py
@@ -184,6 +184,8 @@ class CPU6502:
             if self.memory.vic_snapshot_each_emulated_frame:
                 self.memory.snapshot_vic_render_state()
 
+        self.memory.per_cycle_capture_vic_sample()
+
         return ba_low, ba_blocks_cpu, irq_edge
 
     @staticmethod

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -79,7 +79,7 @@ Run the same PRG or D64 with these combinations and note **which configuration f
 
 ## 5b. Per-cycle video rendering
 
-`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **hires / multicolor / ECM text** scanline-by-scanline from those samples; sprites and bitmap modes still use the same limitations as the beam path unless noted otherwise. See `docs/per_cycle_vic.md`.
+`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **text** (hires / multicolor / ECM) and **bitmap** (hires / multicolor) scanline-by-scanline from those samples; **sprites** still latch once per frame. See `docs/per_cycle_vic.md`.
 
 ## 6. TCP monitor (c64py)
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -71,11 +71,15 @@ Run the same PRG or D64 with these combinations and note **which configuration f
 
 `--video-rendering per-raster` (formerly `accurate`) uses per-raster-line VIC register copies and CIA2 port A (VIC bank) samples. Each of the 25 content rows is dispatched independently to the appropriate pixel renderer (hires text, multicolor text, ECM, hires bitmap, multicolor bitmap) based on **that row's** sampled VIC config; games that flip `$D011`/`$D016`/`$D018`/`$D020`-`$D024` or CIA2-PA between bands (HUD+playfield splits, color bars, charset/bank swaps) compose correctly. The **Python** CPU path calls `MemoryMap.beam_capture_raster_line` from the raster/VIC tick hooks. When the **Rust** fast batch runs with `MemoryMap.beam_render_enabled`, the core writes **`MemoryMap.beam_vic_flat` / `beam_cia2_flat` in place** (no full-buffer copy back per batch); pygame reads those shared bytearrays.
 
-**Granularity:** one sample per raster line, latched at the start of the line. Sub-row effects (mode changes *within* an 8-scanline row, open sideborders, FLI proper, AGSP, per-scanline color stripes inside a row) need the future per-cycle renderer — they will look like they snap to row boundaries under `per-raster`.
+**Granularity:** one sample per raster line, latched at the start of the line. Sub-row effects (mode changes *within* an 8-scanline row, open sideborders, FLI proper, AGSP, per-scanline color stripes inside a row) are better exercised with **`--video-rendering per-cycle`** (text modes today; bitmap still uses the per-frame latch until the bitmap walker lands).
 
 **Border limits:** The presenter samples **one** border color (`$D020`) per raster line from that line’s VIC snapshot. Real hardware and VICE can change the border **several times on the same line**; matching that needs finer-than-line sampling (e.g. cycle-keyed VIC events), not just RAM write batching.
 
 **Charset:** The VIC-II fetches dot patterns from **character ROM** for offsets ``$1000``–``$1FFF`` inside video **banks** ``$0000`` and ``$8000``; the CPU still sees **RAM** at those physical addresses. Pygame uses `MemoryMap.read_vic_charset_glyph_rows` / `read_vic_charset_block_2k` so the boot charset at bank 0 + ``$1000`` matches hardware. For CPU-visible char ROM at ``$D000`` (CHAREN=0), `MemoryMap.read` is still correct.
+
+## 5b. Per-cycle video rendering
+
+`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **hires / multicolor / ECM text** scanline-by-scanline from those samples; sprites and bitmap modes still use the same limitations as the beam path unless noted otherwise. See `docs/per_cycle_vic.md`.
 
 ## 6. TCP monitor (c64py)
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -71,7 +71,7 @@ Run the same PRG or D64 with these combinations and note **which configuration f
 
 `--video-rendering per-raster` (formerly `accurate`) uses per-raster-line VIC register copies and CIA2 port A (VIC bank) samples. Each of the 25 content rows is dispatched independently to the appropriate pixel renderer (hires text, multicolor text, ECM, hires bitmap, multicolor bitmap) based on **that row's** sampled VIC config; games that flip `$D011`/`$D016`/`$D018`/`$D020`-`$D024` or CIA2-PA between bands (HUD+playfield splits, color bars, charset/bank swaps) compose correctly. The **Python** CPU path calls `MemoryMap.beam_capture_raster_line` from the raster/VIC tick hooks. When the **Rust** fast batch runs with `MemoryMap.beam_render_enabled`, the core writes **`MemoryMap.beam_vic_flat` / `beam_cia2_flat` in place** (no full-buffer copy back per batch); pygame reads those shared bytearrays.
 
-**Granularity:** one sample per raster line, latched at the start of the line. Sub-row effects (mode changes *within* an 8-scanline row, open sideborders, FLI proper, AGSP, per-scanline color stripes inside a row) are better exercised with **`--video-rendering per-cycle`** (text modes today; bitmap still uses the per-frame latch until the bitmap walker lands).
+**Granularity:** one sample per raster line, latched at the start of the line. Sub-row effects (mode changes *within* an 8-scanline row, open sideborders, FLI proper, AGSP, per-scanline color stripes inside a row) are better exercised with **`--video-rendering per-cycle`** (text, bitmap, and per-column sprites from the sample grid).
 
 **Border limits:** The presenter samples **one** border color (`$D020`) per raster line from that line’s VIC snapshot. Real hardware and VICE can change the border **several times on the same line**; matching that needs finer-than-line sampling (e.g. cycle-keyed VIC events), not just RAM write batching.
 
@@ -79,7 +79,7 @@ Run the same PRG or D64 with these combinations and note **which configuration f
 
 ## 5b. Per-cycle video rendering
 
-`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **text** (hires / multicolor / ECM) and **bitmap** (hires / multicolor) scanline-by-scanline from those samples; **sprites** still latch once per frame. See `docs/per_cycle_vic.md`.
+`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **text** (hires / multicolor / ECM), **bitmap** (hires / multicolor), and **sprites** scanline-by-scanline from those samples (sprites use the same per-column register snapshot as the background). See `docs/per_cycle_vic.md`.
 
 ## 6. TCP monitor (c64py)
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -79,7 +79,7 @@ Run the same PRG or D64 with these combinations and note **which configuration f
 
 ## 5b. Per-cycle video rendering
 
-`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **text** (hires / multicolor / ECM), **bitmap** (hires / multicolor), and **sprites** scanline-by-scanline from those samples (sprites use the same per-column register snapshot as the background). See `docs/per_cycle_vic.md`.
+`--video-rendering per-cycle` enables a 40×200 sample grid (`MemoryMap.per_cycle_*`) filled from `CPU6502._vic_tick_one` (requires `accurate-python` VIC — forced automatically when needed). Pygame composes **text** (hires / multicolor / ECM), **bitmap** (hires / multicolor), and **sprites** scanline-by-scanline from those samples (sprites use the same per-column register snapshot as the background). **Performance:** accurate-python stepping dominates wall time; set `C64PY_PER_CYCLE_NO_SPRITES=1` to skip sprite overlay if you only need background splits. See `docs/per_cycle_vic.md`.
 
 ## 6. TCP monitor (c64py)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,7 +36,7 @@ If none exist, the built-in defaults (see below) are used.
 
 ```toml
 [video]
-rendering  = "per-frame"     # "per-frame" | "per-raster" | "per-cycle" (per-cycle → per-raster until implemented)
+rendering  = "per-frame"     # "per-frame" | "per-raster" | "per-cycle" (per-cycle needs accurate-python VIC; see docs/per_cycle_vic.md)
 standard   = "pal"           # "pal" | "ntsc"
 scale      = 2               # graphics window scale factor (integer)
 fps        = 30              # graphics present rate cap

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -67,23 +67,27 @@ VIC shadow (`$D000`–`$D03F`) and CIA2 port A into the slot for the current
 Fast VIC mode does not call `_vic_tick_one`, so per-cycle buffers stay
 empty unless accurate VIC is enabled.
 
-**B4 (CLI):** `--video-rendering per-cycle` (or `video.rendering = "per-cycle"`
-in TOML) turns on `per_cycle_render_enabled`, primes buffers at startup, and
-forces `--vic-emulation accurate-python` when needed so `_vic_tick_one` runs
-each cycle. `--accurate` normally selects per-raster + accurate-rust; if
-you combine it with per-cycle (CLI or merged config), VIC stays on
-accurate-python so sampling works.
+**B4 (CLI):** `--video-rendering per-cycle` turns on `per_cycle_render_enabled`, primes buffers
+at startup, and (when `c64py_rust_core` is built) prefers **`--vic-emulation accurate-rust`**
+with hybrid VIC so `run_fast_batch` fills the flat buffers each visible cycle; use
+`C64PY_RUST_PER_CYCLE=0` to keep sampling in Python. Without the Rust extension, per-cycle
+still requires **`accurate-python`** VIC so `_vic_tick_one` runs each cycle.
 
-**B3 (text + bitmap + sprites):** `PygameInterface._render_frame_per_cycle` reads the
-sample grid and draws hires / multicolor / ECM text, **hires / multicolor bitmap**, and
-**sprites** (per 8-pixel column from the sample at that cycle). Sprite-sprite order matches
-silicon (**sprite 0 in front of sprite 7**; compositor draws 7 → 0). ``$D01B``
-sprite/background priority is approximated for opaque foreground pixels in hires and
-multicolor text/bitmap rows (hires bitmap: per-bit ``1`` pixels block behind-sprites). True
+**B3 (text + bitmap + sprites):** `PygameInterface._render_frame_per_cycle` (or
+`_core.composite_per_cycle_frame` when enabled) reads the sample grid and draws hires /
+multicolor / ECM text, **hires / multicolor bitmap**, and **sprites**. Per-column samples
+drive sprite **X**, **enable**, and video-matrix context; **$D017 / $D01D / $D01C / $D01B** and
+sprite colours **$D025–$D02E** are taken from the **first visible cycle** of each raster line
+(column 0) so one sprite is not torn across mixed expansion/palette bytes when the KERNAL
+changes those registers between character cycles. **Sprite X/Y expansion** is honoured
+(48×42 screen extent from 24×21 data). Sprite-sprite order matches silicon (**sprite 0 in
+front of sprite 7**; compositor draws 7 → 0). ``$D01B`` sprite/background priority is
+approximated for opaque foreground pixels in hires and multicolor text/bitmap rows. True
 BA/DMA timing is still approximated compared to silicon.
 
-5. **Sprite DMA / finer priority.** Further align sprite drawing with VIC fetch timing and
-   border/latch edge cases beyond the current ``$D01B`` foreground mask.
+5. **Sprite DMA / finer priority.** Further align sprite drawing with VIC internal fetch
+   buffers, multiplex edge cases, and border/latch timing beyond the current foreground mask
+   and line-latched attribute registers.
 
 6. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
    / TOML. The first regression target is a frame where per-raster output
@@ -91,18 +95,10 @@ BA/DMA timing is still approximated compared to silicon.
    `scripts/render_n_frames.py` supports `--video-rendering per-cycle` for
    snapshot-based frame hashes.
 
-7. **Performance.** The dominant cost is **`--vic-emulation accurate-python`**
-   (full Python VIC cycle step per CPU cycle). Host compositing is secondary but
-   was improved by: (a) writing only the **flat** `per_cycle_vic_flat` /
-   `per_cycle_cia2_flat` in the sampler — no per-slot `bytes(64)` allocations
-   (~8000/frame); (b) **bulk priming** of those flats at startup; (c) an LRU
-   **glyph row cache** in the pygame path for repeated screen codes; (d) optional
-   `C64PY_PER_CYCLE_NO_SPRITES=1` to skip the per-column sprite overlay when you
-   only care about background splits. Expect per-cycle to remain much slower than
-   per-raster for interactive use; use per-raster for daily play. A future win is
-   one **native compositor** pass per frame over the flat buffers (see
-   `docs/rust_core.md`); that does not remove the Python VIC stepping cost unless
-   sampling moves to Rust too.
+7. **Performance.** With the Rust extension, hybrid VIC + **native compositor** (`_core.composite_per_cycle_frame`,
+   on by default; `C64PY_RUST_COMPOSITE=0` for Python drawing) makes per-cycle usable for
+   interactive play. Optional `C64PY_PER_CYCLE_NO_SPRITES=1` skips sprite overlay. Remaining
+   cost is dominated by anything still on the Python path (e.g. IEC stepping, debugging).
 
 ## When to implement
 

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -39,6 +39,21 @@ added additively without rewriting the existing renderers:
    stores a per-line snapshot, so this is roughly a 7× expansion of
    that buffer.
 
+### Geometry and buffers
+
+The B1 foundation is checked into `video_beam.py` and `memory.py`:
+
+| Standard | Frame lines | Cycles/line | Content raster window | Content cycle window | Samples/frame |
+|---|---:|---:|---:|---:|---:|
+| PAL | 312 | 63 | 51..250 | 14..53 (0-based VIC cycle) | 8000 |
+| NTSC | 263 | 65 | 51..250 | 14..53 (0-based VIC cycle) | 8000 |
+
+`video_beam.per_cycle_geometry()` returns these bounds and maps a
+`(raster_line, raster_cycle)` pair to a visible sample index, or `None`
+outside the 320x200 content area. `MemoryMap.ensure_per_cycle_buffers()`
+allocates matching VIC and CIA2 snapshot grids plus flat bytearrays for
+future renderer/Rust handoff; it does not render or sample yet.
+
 2. **Pixel-by-pixel renderer.** Walk left-to-right within each
    scanline emitting one pixel at a time using the cycle-correct VIC
    state. Standard text, multicolor text, ECM, hires bitmap and

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -8,10 +8,10 @@ c64py's `--video-rendering` flag offers two tiers today:
   and handles split-screen mode/charset/background-color changes
   across the frame.
 
-A third tier — **`per-cycle`** — is implemented for **text modes** (hires,
-multicolor, ECM): the CPU cycle engine records VIC/CIA2 in a 40×200 sample
-grid, and the pygame path composites one scanline per sample. **Bitmap**
-modes still use the per-frame latch until a bitmap walker lands.
+A third tier — **`per-cycle`** — is implemented for **text** and **bitmap**
+(hires + multicolor) modes: the CPU cycle engine records VIC/CIA2 in a 40×200 sample
+grid, and the pygame path composites one scanline per sample. **Sprites** still use
+the per-frame latch (same as the beam renderer) until a per-cycle sprite pass exists.
 
 The per-raster path samples VIC state only at row boundaries (every 8
 scanlines), so any effect that depends on register changes mid-row
@@ -73,19 +73,18 @@ each cycle. `--accurate` normally selects per-raster + accurate-rust; if
 you combine it with per-cycle (CLI or merged config), VIC stays on
 accurate-python so sampling works.
 
-**B3 (text walker):** `PygameInterface._render_frame_per_cycle` reads the
-sample grid and draws hires / multicolor / ECM text scanline-by-scanline.
-Sprites still use the end-of-frame latch (same limitation as the beam path).
+**B3 (text + bitmap walkers):** `PygameInterface._render_frame_per_cycle` reads the
+sample grid and draws hires / multicolor / ECM text and **hires / multicolor bitmap**
+scanline-by-scanline. Sprites still use the end-of-frame latch (same limitation as the beam path).
 
-2. **Bitmap / sprite parity.** Extend the sampling grid to hires and
-   multicolor bitmap rows, then align sprite DMA with per-cycle state
+2. **Sprite DMA parity.** Align sprite compositing with per-cycle VIC state
    (today sprites still latch once per frame like the beam path).
 
 3. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
    / TOML. The first regression target is a frame where per-raster output
    differs from a known-good reference; `per-cycle` should converge there.
-   Use `scripts/render_n_frames.py` as the harness once it supports the
-   per-cycle buffer path.
+   `scripts/render_n_frames.py` supports `--video-rendering per-cycle` for
+   snapshot-based frame hashes.
 
 4. **Performance.** Expect the per-cycle path to be 5–10× slower than
    per-raster. It is acceptable as a correctness mode, not the

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -8,8 +8,12 @@ c64py's `--video-rendering` flag offers two tiers today:
   and handles split-screen mode/charset/background-color changes
   across the frame.
 
-A third tier — **`per-cycle`** — is filed as future work. The
-per-raster path samples VIC state only at row boundaries (every 8
+A third tier — **`per-cycle`** — is implemented for **text modes** (hires,
+multicolor, ECM): the CPU cycle engine records VIC/CIA2 in a 40×200 sample
+grid, and the pygame path composites one scanline per sample. **Bitmap**
+modes still use the per-frame latch until a bitmap walker lands.
+
+The per-raster path samples VIC state only at row boundaries (every 8
 scanlines), so any effect that depends on register changes mid-row
 or mid-scanline is lost. Examples that need per-cycle resolution:
 
@@ -52,7 +56,7 @@ The B1 foundation is checked into `video_beam.py` and `memory.py`:
 `(raster_line, raster_cycle)` pair to a visible sample index, or `None`
 outside the 320x200 content area. `MemoryMap.ensure_per_cycle_buffers()`
 allocates matching VIC and CIA2 snapshot grids plus flat bytearrays for
-future renderer/Rust handoff; it does not render or sample yet.
+renderer/Rust handoff.
 
 **B2 sampler:** when `MemoryMap.per_cycle_render_enabled` is true,
 `MemoryMap.per_cycle_capture_vic_sample()` runs at the end of each
@@ -62,19 +66,26 @@ VIC shadow (`$D000`–`$D03F`) and CIA2 port A into the slot for the current
 Fast VIC mode does not call `_vic_tick_one`, so per-cycle buffers stay
 empty unless accurate VIC is enabled.
 
-2. **Pixel-by-pixel renderer.** Walk left-to-right within each
-   scanline emitting one pixel at a time using the cycle-correct VIC
-   state. Standard text, multicolor text, ECM, hires bitmap and
-   multicolor bitmap renderers all reduce to "given current VIC
-   state and the next 8 bits of the c-access byte, emit pixels".
-   Sprites overlay on top using the same per-cycle state.
+**B4 (CLI):** `--video-rendering per-cycle` (or `video.rendering = "per-cycle"`
+in TOML) turns on `per_cycle_render_enabled`, primes buffers at startup, and
+forces `--vic-emulation accurate-python` when needed so `_vic_tick_one` runs
+each cycle. `--accurate` normally selects per-raster + accurate-rust; if
+you combine it with per-cycle (CLI or merged config), VIC stays on
+accurate-python so sampling works.
 
-3. **Gating.** Make `per-cycle` opt-in via the existing
-   `--video-rendering` flag. The first regression target is a frame
-   where the per-raster output differs from a known-good reference;
-   `per-cycle` should converge to the reference. Use
-   `scripts/render_n_frames.py` as the harness — it already produces
-   reproducible frame hashes from a snapshot.
+**B3 (text walker):** `PygameInterface._render_frame_per_cycle` reads the
+sample grid and draws hires / multicolor / ECM text scanline-by-scanline.
+Sprites still use the end-of-frame latch (same limitation as the beam path).
+
+2. **Bitmap / sprite parity.** Extend the sampling grid to hires and
+   multicolor bitmap rows, then align sprite DMA with per-cycle state
+   (today sprites still latch once per frame like the beam path).
+
+3. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
+   / TOML. The first regression target is a frame where per-raster output
+   differs from a known-good reference; `per-cycle` should converge there.
+   Use `scripts/render_n_frames.py` as the harness once it supports the
+   per-cycle buffer path.
 
 4. **Performance.** Expect the per-cycle path to be 5–10× slower than
    per-raster. It is acceptable as a correctness mode, not the

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -76,11 +76,14 @@ accurate-python so sampling works.
 
 **B3 (text + bitmap + sprites):** `PygameInterface._render_frame_per_cycle` reads the
 sample grid and draws hires / multicolor / ECM text, **hires / multicolor bitmap**, and
-**sprites** (per 8-pixel column from the sample at that cycle). Sprite-sprite priority and
-true BA/DMA timing are still approximated compared to silicon.
+**sprites** (per 8-pixel column from the sample at that cycle). Sprite-sprite order matches
+silicon (**sprite 0 in front of sprite 7**; compositor draws 7 → 0). ``$D01B``
+sprite/background priority is approximated for opaque foreground pixels in hires and
+multicolor text/bitmap rows (hires bitmap: per-bit ``1`` pixels block behind-sprites). True
+BA/DMA timing is still approximated compared to silicon.
 
-5. **Sprite DMA / priority.** Further align sprite drawing with VIC fetch timing and
-   `$D01B` priority (today the compositor is host-side from register snapshots).
+5. **Sprite DMA / finer priority.** Further align sprite drawing with VIC fetch timing and
+   border/latch edge cases beyond the current ``$D01B`` foreground mask.
 
 6. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
    / TOML. The first regression target is a frame where per-raster output

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -54,6 +54,14 @@ outside the 320x200 content area. `MemoryMap.ensure_per_cycle_buffers()`
 allocates matching VIC and CIA2 snapshot grids plus flat bytearrays for
 future renderer/Rust handoff; it does not render or sample yet.
 
+**B2 sampler:** when `MemoryMap.per_cycle_render_enabled` is true,
+`MemoryMap.per_cycle_capture_vic_sample()` runs at the end of each
+`CPU6502._vic_tick_one()` (accurate VIC path only). It copies the current
+VIC shadow (`$D000`–`$D03F`) and CIA2 port A into the slot for the current
+`(raster_line, raster_cycle)` when that pair lies in the visible window.
+Fast VIC mode does not call `_vic_tick_one`, so per-cycle buffers stay
+empty unless accurate VIC is enabled.
+
 2. **Pixel-by-pixel renderer.** Walk left-to-right within each
    scanline emitting one pixel at a time using the cycle-correct VIC
    state. Standard text, multicolor text, ECM, hires bitmap and

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -56,8 +56,8 @@ The B1 foundation is checked into `video_beam.py` and `memory.py`:
 `video_beam.per_cycle_geometry()` returns these bounds and maps a
 `(raster_line, raster_cycle)` pair to a visible sample index, or `None`
 outside the 320x200 content area. `MemoryMap.ensure_per_cycle_buffers()`
-allocates matching VIC and CIA2 snapshot grids plus flat bytearrays for
-renderer/Rust handoff.
+allocates matching VIC and CIA2 **flat** bytearrays (`per_cycle_vic_flat`,
+`per_cycle_cia2_flat`) for the renderer (and a future native compositor).
 
 **B2 sampler:** when `MemoryMap.per_cycle_render_enabled` is true,
 `MemoryMap.per_cycle_capture_vic_sample()` runs at the end of each
@@ -88,10 +88,18 @@ true BA/DMA timing are still approximated compared to silicon.
    `scripts/render_n_frames.py` supports `--video-rendering per-cycle` for
    snapshot-based frame hashes.
 
-7. **Performance.** Expect the per-cycle path to be 5–10× slower than
-   per-raster. It is acceptable as a correctness mode, not the
-   default. Consider a Rust implementation in `c64py-core` once the
-   Python prototype is stable.
+7. **Performance.** The dominant cost is **`--vic-emulation accurate-python`**
+   (full Python VIC cycle step per CPU cycle). Host compositing is secondary but
+   was improved by: (a) writing only the **flat** `per_cycle_vic_flat` /
+   `per_cycle_cia2_flat` in the sampler — no per-slot `bytes(64)` allocations
+   (~8000/frame); (b) **bulk priming** of those flats at startup; (c) an LRU
+   **glyph row cache** in the pygame path for repeated screen codes; (d) optional
+   `C64PY_PER_CYCLE_NO_SPRITES=1` to skip the per-column sprite overlay when you
+   only care about background splits. Expect per-cycle to remain much slower than
+   per-raster for interactive use; use per-raster for daily play. A future win is
+   one **native compositor** pass per frame over the flat buffers (see
+   `docs/rust_core.md`); that does not remove the Python VIC stepping cost unless
+   sampling moves to Rust too.
 
 ## When to implement
 

--- a/docs/per_cycle_vic.md
+++ b/docs/per_cycle_vic.md
@@ -8,10 +8,11 @@ c64py's `--video-rendering` flag offers two tiers today:
   and handles split-screen mode/charset/background-color changes
   across the frame.
 
-A third tier — **`per-cycle`** — is implemented for **text** and **bitmap**
-(hires + multicolor) modes: the CPU cycle engine records VIC/CIA2 in a 40×200 sample
-grid, and the pygame path composites one scanline per sample. **Sprites** still use
-the per-frame latch (same as the beam renderer) until a per-cycle sprite pass exists.
+A third tier — **`per-cycle`** — is implemented for **text**, **bitmap**
+(hires + multicolor), and **sprites**: the CPU cycle engine records VIC/CIA2 in a 40×200 sample
+grid, and the pygame path composites one scanline per sample. Sprites use the **same**
+per-column register samples as the background (so mid-raster X/Y/pointer changes show up);
+sprite DMA timing and collisions are still not modeled here.
 
 The per-raster path samples VIC state only at row boundaries (every 8
 scanlines), so any effect that depends on register changes mid-row
@@ -73,20 +74,21 @@ each cycle. `--accurate` normally selects per-raster + accurate-rust; if
 you combine it with per-cycle (CLI or merged config), VIC stays on
 accurate-python so sampling works.
 
-**B3 (text + bitmap walkers):** `PygameInterface._render_frame_per_cycle` reads the
-sample grid and draws hires / multicolor / ECM text and **hires / multicolor bitmap**
-scanline-by-scanline. Sprites still use the end-of-frame latch (same limitation as the beam path).
+**B3 (text + bitmap + sprites):** `PygameInterface._render_frame_per_cycle` reads the
+sample grid and draws hires / multicolor / ECM text, **hires / multicolor bitmap**, and
+**sprites** (per 8-pixel column from the sample at that cycle). Sprite-sprite priority and
+true BA/DMA timing are still approximated compared to silicon.
 
-2. **Sprite DMA parity.** Align sprite compositing with per-cycle VIC state
-   (today sprites still latch once per frame like the beam path).
+5. **Sprite DMA / priority.** Further align sprite drawing with VIC fetch timing and
+   `$D01B` priority (today the compositor is host-side from register snapshots).
 
-3. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
+6. **Gating and golden tests.** `per-cycle` is opt-in via `--video-rendering`
    / TOML. The first regression target is a frame where per-raster output
    differs from a known-good reference; `per-cycle` should converge there.
    `scripts/render_n_frames.py` supports `--video-rendering per-cycle` for
    snapshot-based frame hashes.
 
-4. **Performance.** Expect the per-cycle path to be 5–10× slower than
+7. **Performance.** Expect the per-cycle path to be 5–10× slower than
    per-raster. It is acceptable as a correctness mode, not the
    default. Consider a Rust implementation in `c64py-core` once the
    Python prototype is stable.

--- a/docs/rust_core.md
+++ b/docs/rust_core.md
@@ -21,18 +21,21 @@ built (`maturin develop --manifest-path rust/c64py-core/Cargo.toml`).
   (KERNAL LOAD/SAVE hooks), and `$FF5B`/`$FFCF` when there is no
   KERNAL ROM.
 - Optional reSID lockstep clocking from inside the Rust batch via the
-  shared `resid_c.dylib`.
+  shared `resid_c.dylib` (including hybrid-IRQ phases so SID time matches
+  the emulated cycle counter).
+- **Per-cycle pygame tier:** with the extension built, hybrid VIC fills
+  `per_cycle_vic_flat` / `per_cycle_cia2_flat` during `run_fast_batch`, and
+  `_core.composite_per_cycle_frame` draws text, bitmap, and sprites in one
+  pass (sprite expansion, line-latched attribute regs, ``$D01B`` vs opaque fg;
+  env toggles `C64PY_RUST_PER_CYCLE`, `C64PY_RUST_COMPOSITE`).
 - Differential test coverage: `test/test_rust_core_parity.py`,
   `test/test_kernal_hook_rts.py`, plus Rust `cargo test` in
   `rust/c64py-core/`.
 
 ## Remaining work
 
-1. **BA / CPU-stall arbitration** in the Rust hybrid VIC path.
-   The Python per-cycle accurate-VIC engine stalls the CPU when the
-   VIC pulls BA low for c-access / sprite DMA fetches; the Rust
-   hybrid path currently does not. This is the main known-gap vs
-   `--vic-emulation accurate-python`.
+1. **Rust hybrid vs ``accurate-python``** — parity for newly reported VIC/CPU
+   timing cases; see `test/test_rust_core_parity.py`.
 
 2. **Coarse "run N cycles with breakpoints"**. Today each batch is
    bounded by `C64PY_RUST_BATCH` (default 64) plus stop PCs; a
@@ -43,9 +46,3 @@ built (`maturin develop --manifest-path rust/c64py-core/Cargo.toml`).
 3. **Trace / UDP-debug paths** still force Python `step()` per
    instruction. A native trace emitter in Rust would let those modes
    keep batching.
-
-4. **Per-cycle rendering with Rust.** When `c64py_rust_core` is built, `--video-rendering per-cycle`
-   defaults to **`--vic-emulation accurate-rust`**: `run_fast_batch` runs the hybrid VIC and fills
-   `per_cycle_vic_flat` / `per_cycle_cia2_flat` each visible-cycle (disable with `C64PY_RUST_PER_CYCLE=0`).
-   Pygame can composite that grid in one FFI call via `_core.composite_per_cycle_frame` (on by default;
-   set `C64PY_RUST_COMPOSITE=0` to use the Python compositor). See [`per_cycle_vic.md`](per_cycle_vic.md).

--- a/docs/rust_core.md
+++ b/docs/rust_core.md
@@ -44,10 +44,8 @@ built (`maturin develop --manifest-path rust/c64py-core/Cargo.toml`).
    instruction. A native trace emitter in Rust would let those modes
    keep batching.
 
-4. **Per-cycle Pygame compositor.** See [`per_cycle_vic.md`](per_cycle_vic.md).
-   Text, bitmap, and sprites are composited in Python from the 40×200 sample grid.
-   This mode forces `accurate-python` VIC, so **`run_fast_batch` is not used** and
-   installing `c64py_rust_core` does not accelerate it today. A plausible next step is
-   one **native call per frame** (or per scanline) that reads `MemoryMap.per_cycle_*`
-   flat buffers plus RAM and writes RGB888, without porting the sampler until the Rust
-   hybrid VIC matches BA stalls.
+4. **Per-cycle rendering with Rust.** When `c64py_rust_core` is built, `--video-rendering per-cycle`
+   defaults to **`--vic-emulation accurate-rust`**: `run_fast_batch` runs the hybrid VIC and fills
+   `per_cycle_vic_flat` / `per_cycle_cia2_flat` each visible-cycle (disable with `C64PY_RUST_PER_CYCLE=0`).
+   Pygame can composite that grid in one FFI call via `_core.composite_per_cycle_frame` (on by default;
+   set `C64PY_RUST_COMPOSITE=0` to use the Python compositor). See [`per_cycle_vic.md`](per_cycle_vic.md).

--- a/docs/rust_core.md
+++ b/docs/rust_core.md
@@ -44,6 +44,10 @@ built (`maturin develop --manifest-path rust/c64py-core/Cargo.toml`).
    instruction. A native trace emitter in Rust would let those modes
    keep batching.
 
-4. **Per-cycle VIC renderer.** See [`per_cycle_vic.md`](per_cycle_vic.md);
-   when that lands the Python prototype will likely move into Rust
-   for performance.
+4. **Per-cycle Pygame compositor.** See [`per_cycle_vic.md`](per_cycle_vic.md).
+   Text, bitmap, and sprites are composited in Python from the 40×200 sample grid.
+   This mode forces `accurate-python` VIC, so **`run_fast_batch` is not used** and
+   installing `c64py_rust_core` does not accelerate it today. A plausible next step is
+   one **native call per frame** (or per scanline) that reads `MemoryMap.per_cycle_*`
+   flat buffers plus RAM and writes RGB888, without porting the sampler until the Rust
+   hybrid VIC matches BA stalls.

--- a/emulator.py
+++ b/emulator.py
@@ -274,6 +274,38 @@ class C64:
             ema = max(-mx, ema - self._SPEED_THROTTLE_HZ_NUDGE_FAST)
         self._speed_sleep_overshoot_ema = max(-mx, min(mx, ema))
 
+    def _resid_audio_backpressure_if_needed(self) -> None:
+        """If the lockstep reSID queue is far ahead of pygame playback, sleep briefly.
+
+        Wall-clock CPU throttling targets ~985/1022 kHz but host timer jitter (and bursty
+        Rust batches) can leave the PCM queue growing to multiple seconds — heard as
+        increasing A/V lag. Cap effective backlog with a short sleep when pending bytes
+        exceed ``C64PY_RESID_MAX_PENDING_SEC`` × sample_rate (default ~0.35 s).
+        """
+        sid = getattr(self, "sid", None)
+        if sid is None or not hasattr(sid, "get_resid_audio_stats"):
+            return
+        if not getattr(sid, "_cpu_lockstep", True) and not getattr(sid, "_rust_pcm_mode", False):
+            return
+        try:
+            st = sid.get_resid_audio_stats()
+            pending = int(st.get("pending_bytes_now", 0))
+        except Exception:
+            return
+        try:
+            max_sec = float(os.environ.get("C64PY_RESID_MAX_PENDING_SEC", "0.35").strip())
+        except ValueError:
+            max_sec = 0.35
+        max_sec = max(0.08, min(max_sec, 3.0))
+        sr = float(getattr(sid, "_sample_rate", 44100) or 44100)
+        cap = int(max_sec * sr * 2.0)
+        excess = pending - cap
+        if excess <= 0:
+            return
+        nap = min(0.25, excess / (sr * 2.0))
+        if nap >= self._SPEED_THROTTLE_MIN_SLEEP_SEC:
+            time.sleep(nap)
+
     def throttle_emulation_if_needed(self, cycles: int) -> None:
         """Sleep if we're ahead of real time for the configured CPU clock (no-op if turbo).
 
@@ -286,9 +318,14 @@ class C64:
         and IRQ phase; that still requires advancing the chip model each emulated cycle
         (or a proven fast-forward with equivalent state).
 
+        When reSID lockstep (or Rust-fed PCM) is enabled, :meth:`_resid_audio_backpressure_if_needed`
+        runs first so the pending PCM queue cannot drift many seconds ahead of SDL playback
+        (tunable via ``C64PY_RESID_MAX_PENDING_SEC``).
+
         """
         if getattr(self, "turbo", False):
             return
+        self._resid_audio_backpressure_if_needed()
         if not hasattr(self, "_speed_throttle_deadline"):
             self.reset_speed_throttle()
         self._speed_throttle_per_second_log_and_tune(cycles)

--- a/graphics.py
+++ b/graphics.py
@@ -1226,6 +1226,7 @@ class PygameInterface:
         self,
         mem: "MemoryMap",
         regb: memoryview,
+        regb_line: memoryview,
         pra: int,
         y_win: int,
         col: int,
@@ -1238,14 +1239,29 @@ class PygameInterface:
         so sprites line up with the latched path; register values come from the per-cycle grid
         so mid-raster sprite register changes affect the correct column.
 
+        ``regb_line`` is the VIC snapshot for **column 0** of this raster line (cycle 14). Sprite
+        attributes that games typically hold stable for the line—$D017/$D01D expansion, $D01C
+        multicolor, $D01B priority, $D025–$D026 and $D027–$D02E colors—are read from
+        ``regb_line`` so IRQs that rewrite them between character cycles do not tear one sprite
+        into mixed graphics. Sprite X, MSBs, $D015 enable, and $D011/$D016/$D018 mode (for pointer
+        matrix) still use the per-column ``regb`` sample.
+
         Sprites are composited **7 → 0** (VIC-II: lower index in front). ``fg_opaque`` marks which
         of the eight column pixels count as opaque foreground for ``$D01B`` sprite-behind-gfx.
         """
         if self._rgb_frame is None:
             return
 
-        def rb(i: int) -> int:
+        def rb_col(i: int) -> int:
             return int(regb[i]) if i < len(regb) else 0
+
+        def rb_line(i: int) -> int:
+            return int(regb_line[i]) if i < len(regb_line) else 0
+
+        def rb_spr(i: int) -> int:
+            if i in (0x17, 0x1D, 0x1C, 0x1B) or (0x25 <= i <= 0x2E):
+                return rb_line(i)
+            return rb_col(i)
 
         ram = mem.ram
         vic_bank = (3 - (int(pra) & 0x03)) * 0x4000
@@ -1261,24 +1277,24 @@ class PygameInterface:
         st = int(self._screen_rect.top)
         sb = int(self._screen_rect.bottom)
 
-        mc0 = self._palette.get(rb(0x25) & 0x0F, (0, 0, 0))
-        mc1 = self._palette.get(rb(0x26) & 0x0F, (0, 0, 0))
+        mc0 = self._palette.get(rb_spr(0x25) & 0x0F, (0, 0, 0))
+        mc1 = self._palette.get(rb_spr(0x26) & 0x0F, (0, 0, 0))
         mcr0, mcg0, mcb0 = mc0
         mcr1, mcg1, mcb1 = mc1
 
         x0 = col * self.CHAR_WIDTH
 
-        sprite_pri = rb(0x1B)
+        sprite_pri = rb_spr(0x1B)
         fo = fg_opaque if len(fg_opaque) == 8 else ((False,) * 8)
 
-        y_exp_mask = rb(0x17)
-        x_exp_mask = rb(0x1D)
+        y_exp_mask = rb_spr(0x17)
+        x_exp_mask = rb_spr(0x1D)
 
         for sprite_num in range(7, -1, -1):
-            if not (rb(0x15) & (1 << sprite_num)):
+            if not (rb_col(0x15) & (1 << sprite_num)):
                 continue
             behind_gfx = (sprite_pri >> sprite_num) & 1
-            y_vic = rb(sprite_num * 2 + 1)
+            y_vic = rb_col(sprite_num * 2 + 1)
             # Same as _render_sprites: py = screen_top + (y_vic - 50) + row  →  row = y_win - y_vic + 50
             row_disp = y_win - y_vic + 50
             y_exp = (y_exp_mask >> sprite_num) & 1
@@ -1291,12 +1307,12 @@ class PygameInterface:
                     continue
                 row = row_disp
 
-            x_vic = rb(sprite_num * 2) + (256 if (rb(0x10) & (1 << sprite_num)) else 0)
+            x_vic = rb_col(sprite_num * 2) + (256 if (rb_col(0x10) & (1 << sprite_num)) else 0)
             sprite_x = x_vic - 24
             x_exp = (x_exp_mask >> sprite_num) & 1
             max_rel = 48 if x_exp else 24
-            multicolor = (rb(0x1C) & (1 << sprite_num)) != 0
-            sp_idx = rb(0x27 + sprite_num) & 0x0F
+            multicolor = (rb_spr(0x1C) & (1 << sprite_num)) != 0
+            sp_idx = rb_spr(0x27 + sprite_num) & 0x0F
             sp = self._palette.get(sp_idx, (255, 255, 255))
             spr, spg, spb = sp
 
@@ -1464,6 +1480,11 @@ class PygameInterface:
             py = screen_top + y_win
             self._rgb_frame.fill_rect(screen_left, py, content_px_w, 1, bg_scan)
 
+            o_line = idx_bg * 64
+            regb_line = flat_mv[o_line : o_line + 64]
+            if not any(regb_line):
+                regb_line = memoryview(mem._vic_regs)[:64]
+
             text_row = y_win // self.CHAR_HEIGHT
             scan = y_win % self.CHAR_HEIGHT
             for col in range(geom.content_cycles):
@@ -1507,7 +1528,7 @@ class PygameInterface:
                         else:
                             fg_op = self._vic_fg_opaque_hires_row(byte)
                         self._per_cycle_overlay_sprites_eight_pixels(
-                            mem, regb, pra, y_win, col, py, fg_op
+                            mem, regb, regb_line, pra, y_win, col, py, fg_op
                         )
                     continue
 
@@ -1551,7 +1572,7 @@ class PygameInterface:
                     else:
                         fg_op = self._vic_fg_opaque_hires_row(row_byte_text)
                     self._per_cycle_overlay_sprites_eight_pixels(
-                        mem, regb, pra, y_win, col, py, fg_op
+                        mem, regb, regb_line, pra, y_win, col, py, fg_op
                     )
 
         if mem.vic_render_snapshots:

--- a/graphics.py
+++ b/graphics.py
@@ -872,6 +872,55 @@ class PygameInterface:
         fg = self._palette.get(fg_idx, (255, 255, 255))
         self._rgb_frame.plot_hires_glyph(x, y, rows, fg)
 
+    def _plot_hires_text_scanline(self, x: int, y: int, row_byte: int, fg_idx: int) -> None:
+        """Draw one hires text raster (8×1); unset bits leave the existing background."""
+        fg = self._palette.get(fg_idx, (255, 255, 255))
+        fr, fg_g, fb = fg
+        buf = self._rgb_frame._buf
+        w = self._rgb_frame.width
+        h = self._rgb_frame.height
+        if not (0 <= y < h):
+            return
+        base_row = y * w * 3
+        for xx in range(8):
+            if not (row_byte & (1 << (7 - xx))):
+                continue
+            px = x + xx
+            if not (0 <= px < w):
+                continue
+            i = base_row + px * 3
+            buf[i] = fr
+            buf[i + 1] = fg_g
+            buf[i + 2] = fb
+
+    def _plot_mcm_text_scanline(
+        self,
+        x: int,
+        y: int,
+        row_byte: int,
+        char_color_idx: int,
+        bg_i: int,
+        c1_i: int,
+        c2_i: int,
+    ) -> None:
+        """One multicolor text raster line (8×1): four 2-bit wide pixels."""
+        p0 = self._palette.get(bg_i, (0, 0, 0))
+        p1 = self._palette.get(c1_i, (0, 0, 0))
+        p2 = self._palette.get(c2_i, (0, 0, 0))
+        p3 = self._palette.get(char_color_idx, (0, 0, 0))
+        for pair in range(4):
+            bits = (row_byte >> (6 - pair * 2)) & 0x03
+            if bits == 0:
+                c = p0
+            elif bits == 1:
+                c = p1
+            elif bits == 2:
+                c = p2
+            else:
+                c = p3
+            px = x + pair * 2
+            self._rgb_frame.fill_rect(px, y, 2, 1, c)
+
     def _petscii_to_screen_code(self, petscii_char: int) -> int:
         return self.emulator._petscii_to_screen_code(petscii_char)
 
@@ -1142,6 +1191,170 @@ class PygameInterface:
                 if screen_right < native_w:
                     self._rgb_frame.fill_rect(screen_right, y, native_w - screen_right, 1, c)
 
+    def _render_frame_per_cycle(self) -> None:
+        """Per-cycle video: VIC/CIA2 samples on a 40×200 grid (see ``video_beam.per_cycle_geometry``).
+
+        Text modes (hires, multicolor, ECM) use the sampled registers per character column
+        and scanline. Bitmap modes are not composited here yet — falls back to the latched
+        path. Sprites use the same end-of-frame latch as :meth:`_render_frame_beam`.
+        """
+        from .video_beam import content_row_to_raster_line, per_cycle_geometry
+
+        mem = self.emulator.memory
+        flat = mem.per_cycle_vic_flat
+        cia = mem.per_cycle_cia2_flat
+        if (
+            not getattr(mem, "per_cycle_render_enabled", False)
+            or flat is None
+            or cia is None
+            or not getattr(mem, "per_cycle_snapshots_primed", False)
+        ):
+            self._render_frame_latched()
+            return
+
+        vs = mem.video_standard
+        geom = per_cycle_geometry(vs)
+        flat_mv = memoryview(flat)
+        mode0 = mem._display_mode_from_vic_bytes(flat_mv[0:64])
+        if mode0["bitmap_mode"]:
+            if mem.vic_render_snapshots:
+                mem.snapshot_vic_render_state()
+            self._render_frame_latched()
+            return
+
+        nlines = geom.raster_lines
+        total_lines = nlines
+        content_first = content_row_to_raster_line(0, vs)
+        content_h = geom.content_height
+        top_lines = max(0, min(total_lines, content_first))
+        bottom_lines = max(0, total_lines - (content_first + content_h))
+        border_px = int(self.border_size)
+        native_h = int(self._rgb_frame.height)
+        native_w = int(self._rgb_frame.width)
+        screen_left = int(self._screen_rect.left)
+        screen_top = int(self._screen_rect.top)
+        screen_w = int(self._screen_rect.width)
+        screen_h = int(self._screen_rect.height)
+        screen_right = screen_left + screen_w
+
+        def _border_regb_for_rl(rl: int) -> memoryview:
+            rl %= nlines
+            y_win = rl - geom.content_first_raster
+            if 0 <= y_win < geom.content_height and len(flat_mv) >= (y_win * geom.content_cycles + 1) * 64:
+                o = (y_win * geom.content_cycles) * 64
+                return flat_mv[o : o + 64]
+            return memoryview(mem._vic_regs)[:64]
+
+        for y in range(native_h):
+            if border_px > 0 and y < border_px:
+                rl = int((y * top_lines) / border_px) if top_lines > 0 else 0
+            elif y < border_px + content_h:
+                rl = content_first + (y - border_px)
+            else:
+                yy = y - (border_px + content_h)
+                rl = (content_first + content_h) + (
+                    int((yy * bottom_lines) / border_px) if border_px > 0 else 0
+                )
+            rl %= nlines
+            regb = _border_regb_for_rl(rl)
+            border_code = regb[0x20] & 0x0F if len(regb) > 0x20 else 0x0E
+            if border_code == 0 and not any(regb):
+                border_code = 0x0E
+            c = self._palette.get(border_code, (0, 0, 0))
+            if y < screen_top or y >= screen_top + screen_h:
+                self._rgb_frame.fill_rect(0, y, native_w, 1, c)
+            else:
+                if screen_left > 0:
+                    self._rgb_frame.fill_rect(0, y, screen_left, 1, c)
+                if screen_right < native_w:
+                    self._rgb_frame.fill_rect(screen_right, y, native_w - screen_right, 1, c)
+
+        ram = mem.ram
+        content_px_w = geom.content_cycles * self.CHAR_WIDTH
+        for y_win in range(geom.content_height):
+            idx_bg = y_win * geom.content_cycles
+            o_bg = idx_bg * 64
+            regb_bg = flat_mv[o_bg : o_bg + 64]
+            if not any(regb_bg):
+                regb_bg = memoryview(mem._vic_regs)[:64]
+            bg_scan = self._palette.get(regb_bg[0x21] & 0x0F, (0, 0, 0))
+            py = screen_top + y_win
+            self._rgb_frame.fill_rect(screen_left, py, content_px_w, 1, bg_scan)
+
+            text_row = y_win // self.CHAR_HEIGHT
+            scan = y_win % self.CHAR_HEIGHT
+            for col in range(geom.content_cycles):
+                idx = y_win * geom.content_cycles + col
+                o = idx * 64
+                regb = flat_mv[o : o + 64]
+                pra = int(cia[idx]) & 0xFF
+                if not any(regb):
+                    regb = memoryview(mem._vic_regs)[:64]
+                    pra = mem.cia2_pra & 0xFF
+                mode_info = mem._display_mode_from_vic_bytes(regb)
+                vic_bank = (3 - (pra & 0x03)) * 0x4000
+                bg_colors = [
+                    regb[0x21] & 0x0F,
+                    regb[0x22] & 0x0F,
+                    regb[0x23] & 0x0F,
+                    regb[0x24] & 0x0F,
+                ]
+                screen_base = (vic_bank + mode_info["screen_base"]) & 0xFFFF
+                char_base = mode_info["char_base"]
+                idx_scr = text_row * self.SCREEN_COLS + col
+                raw_code = ram[(screen_base + idx_scr) & 0xFFFF]
+                color_code = ram[COLOR_MEM + idx_scr] & 0x0F
+                x = screen_left + col * self.CHAR_WIDTH
+
+                extended_color = bool(mode_info.get("extended_color", False))
+                multicolor_text = bool(mode_info.get("multicolor")) and not extended_color
+
+                if extended_color:
+                    bg_index = (raw_code >> 6) & 0x03
+                    code_ecm = raw_code & 0x3F
+                    char_bg = self._palette.get(bg_colors[bg_index], (0, 0, 0))
+                    self._rgb_frame.fill_rect(x, py, self.CHAR_WIDTH, 1, char_bg)
+                    row_bytes = self._fetch_glyph_rows(vic_bank, char_base, code_ecm)
+                    self._plot_hires_text_scanline(x, py, row_bytes[scan], color_code)
+                else:
+                    row_bytes = self._fetch_glyph_rows(vic_bank, char_base, raw_code)
+                    if multicolor_text and (color_code & 0x08):
+                        self._plot_mcm_text_scanline(
+                            x,
+                            py,
+                            row_bytes[scan],
+                            color_code & 0x07,
+                            bg_colors[0],
+                            bg_colors[1],
+                            bg_colors[2],
+                        )
+                    else:
+                        fg = (color_code & 0x07) if multicolor_text else color_code
+                        self._plot_hires_text_scanline(x, py, row_bytes[scan], fg)
+
+        if mem.vic_render_snapshots:
+            mem.snapshot_vic_render_state()
+        self._render_sprites(getattr(mem, "_vic_render_snapshot", None))
+
+    def _render_frame(self) -> None:
+        """Render one frame into the back buffer (per-cycle, beam, or latched)."""
+        mem = self.emulator.memory
+        if (
+            getattr(mem, "per_cycle_render_enabled", False)
+            and mem.per_cycle_vic_flat is not None
+            and getattr(mem, "per_cycle_snapshots_primed", False)
+        ):
+            self._render_frame_per_cycle()
+            return
+        if (
+            getattr(mem, "beam_render_enabled", False)
+            and mem.beam_vic_lines
+            and getattr(mem, "beam_snapshots_primed", False)
+        ):
+            self._render_frame_beam()
+            return
+        self._render_frame_latched()
+
     def _render_frame_latched(self) -> None:
         """Render one frame using the per-frame VIC latch (non-beam path).
 
@@ -1210,19 +1423,7 @@ class PygameInterface:
 
         # Render sprites on top
         self._render_sprites(snap)
-        
-    def _render_frame(self) -> None:
-        """Render one frame into the back buffer (beam or latched)."""
-        mem = self.emulator.memory
-        if (
-            getattr(mem, "beam_render_enabled", False)
-            and mem.beam_vic_lines
-            and getattr(mem, "beam_snapshots_primed", False)
-        ):
-            self._render_frame_beam()
-            return
-        self._render_frame_latched()
-    
+
     def _render_text_mode(self, mode_info: dict, snap: Optional[Tuple[bytes, int]] = None) -> None:
         """Render text mode; charset definitions are read from VIC bank RAM (as the VIC would).
 

--- a/graphics.py
+++ b/graphics.py
@@ -1271,18 +1271,30 @@ class PygameInterface:
         sprite_pri = rb(0x1B)
         fo = fg_opaque if len(fg_opaque) == 8 else ((False,) * 8)
 
+        y_exp_mask = rb(0x17)
+        x_exp_mask = rb(0x1D)
+
         for sprite_num in range(7, -1, -1):
             if not (rb(0x15) & (1 << sprite_num)):
                 continue
             behind_gfx = (sprite_pri >> sprite_num) & 1
             y_vic = rb(sprite_num * 2 + 1)
             # Same as _render_sprites: py = screen_top + (y_vic - 50) + row  →  row = y_win - y_vic + 50
-            row = y_win - y_vic + 50
-            if row < 0 or row >= 21:
-                continue
+            row_disp = y_win - y_vic + 50
+            y_exp = (y_exp_mask >> sprite_num) & 1
+            if y_exp:
+                if row_disp < 0 or row_disp >= 42:
+                    continue
+                row = row_disp // 2
+            else:
+                if row_disp < 0 or row_disp >= 21:
+                    continue
+                row = row_disp
 
             x_vic = rb(sprite_num * 2) + (256 if (rb(0x10) & (1 << sprite_num)) else 0)
             sprite_x = x_vic - 24
+            x_exp = (x_exp_mask >> sprite_num) & 1
+            max_rel = 48 if x_exp else 24
             multicolor = (rb(0x1C) & (1 << sprite_num)) != 0
             sp_idx = rb(0x27 + sprite_num) & 0x0F
             sp = self._palette.get(sp_idx, (255, 255, 255))
@@ -1299,9 +1311,9 @@ class PygameInterface:
                         continue
                     cx = x0 + dx
                     rel_x = cx - sprite_x
-                    if rel_x < 0 or rel_x >= 24:
+                    if rel_x < 0 or rel_x >= max_rel:
                         continue
-                    bp = rel_x // 2
+                    bp = rel_x // 4 if x_exp else rel_x // 2
                     bits = (row_data >> (22 - bp * 2)) & 0x03
                     if bits == 0:
                         continue
@@ -1323,9 +1335,10 @@ class PygameInterface:
                         continue
                     cx = x0 + dx
                     rel_x = cx - sprite_x
-                    if rel_x < 0 or rel_x >= 24:
+                    if rel_x < 0 or rel_x >= max_rel:
                         continue
-                    if not ((row_data >> (23 - rel_x)) & 0x01):
+                    bi = rel_x // 2 if x_exp else rel_x
+                    if not ((row_data >> (23 - bi)) & 0x01):
                         continue
                     px = screen_left + cx
                     if sl <= px < sr and st <= py < sb:
@@ -1892,9 +1905,13 @@ class PygameInterface:
             regb, _ = snap
             sprite_mc0 = regb[0x25] & 0x0F if len(regb) > 0x25 else 0
             sprite_mc1 = regb[0x26] & 0x0F if len(regb) > 0x26 else 0
+            y_exp_mask = regb[0x17] & 0xFF if len(regb) > 0x17 else 0
+            x_exp_mask = regb[0x1D] & 0xFF if len(regb) > 0x1D else 0
         else:
             sprite_mc0 = self.emulator.memory.read(0xD025) & 0x0F
             sprite_mc1 = self.emulator.memory.read(0xD026) & 0x0F
+            y_exp_mask = self.emulator.memory.read(0xD017) & 0xFF
+            x_exp_mask = self.emulator.memory.read(0xD01D) & 0xFF
         
         # Render sprites 7→0 so lower-numbered sprites appear in front (VIC-II order).
         for sprite_num in range(7, -1, -1):
@@ -1906,7 +1923,7 @@ class PygameInterface:
             # Get sprite bitmap data (63 bytes per sprite) in VIC bank RAM
             sprite_addr = sprite_data['sprite_ram_base']
 
-            # Sprites are 24x21 pixels
+            # Sprites are 24x21 pixels of data; X/Y expansion stretches to 48x42 on screen.
             # Offset sprite coordinates to screen space
             # VIC-II sprite coordinates are relative to the display area, not the border
             # Subtract 24 pixels for X to align with display area (standard C64 offset)
@@ -1914,47 +1931,57 @@ class PygameInterface:
             sprite_x = sprite_data['x'] - 24
             sprite_y = sprite_data['y'] - 50
             sprite_color = self._palette.get(sprite_data['color'], (255, 255, 255))
+            y_exp = (y_exp_mask >> sprite_num) & 1
+            x_exp = (x_exp_mask >> sprite_num) & 1
             
             # Render sprite pixels
             if sprite_data['multicolor']:
-                # Multicolor sprite: 12x21 (double-wide pixels)
+                # Multicolor sprite: 12x21 data pairs; each pair is 2 or 4 screen pixels wide.
                 for row in range(21):
                     # Each row is 3 bytes
                     byte_offset = (sprite_addr + row * 3) & 0xFFFF
                     row_data = (mem[byte_offset] << 16) | (mem[(byte_offset + 1) & 0xFFFF] << 8) | mem[(byte_offset + 2) & 0xFFFF]
-                    
-                    for bit_pair in range(12):
-                        pixel_bits = (row_data >> (22 - bit_pair * 2)) & 0x03
-                        
-                        if pixel_bits == 0:
-                            continue  # Transparent
-                        elif pixel_bits == 1:
-                            color = self._palette.get(sprite_mc0, (0, 0, 0))
-                        elif pixel_bits == 2:
-                            color = sprite_color
-                        else:  # pixel_bits == 3
-                            color = self._palette.get(sprite_mc1, (0, 0, 0))
-                        
-                        # Draw double-wide pixel
-                        px = screen_left + sprite_x + bit_pair * 2
-                        py = screen_top + sprite_y + row
-                        # Check if pixel is within screen rect bounds
-                        if (self._screen_rect.left <= px < self._screen_rect.right and 
-                            self._screen_rect.top <= py < self._screen_rect.bottom):
-                            self._rgb_frame.fill_rect(px, py, 2, 1, color)
+                    y_steps = (0, 1) if y_exp else (0,)
+                    for ydup in y_steps:
+                        py = screen_top + sprite_y + row * (2 if y_exp else 1) + ydup
+                        for bit_pair in range(12):
+                            pixel_bits = (row_data >> (22 - bit_pair * 2)) & 0x03
+                            
+                            if pixel_bits == 0:
+                                continue  # Transparent
+                            elif pixel_bits == 1:
+                                color = self._palette.get(sprite_mc0, (0, 0, 0))
+                            elif pixel_bits == 2:
+                                color = sprite_color
+                            else:  # pixel_bits == 3
+                                color = self._palette.get(sprite_mc1, (0, 0, 0))
+                            
+                            px = screen_left + sprite_x + bit_pair * (4 if x_exp else 2)
+                            w = 4 if x_exp else 2
+                            if (self._screen_rect.left <= px < self._screen_rect.right and 
+                                self._screen_rect.top <= py < self._screen_rect.bottom):
+                                self._rgb_frame.fill_rect(px, py, w, 1, color)
             else:
-                # Hi-res sprite: 24x21
+                # Hi-res sprite: 24x21 data bits
                 for row in range(21):
                     byte_offset = (sprite_addr + row * 3) & 0xFFFF
                     row_data = (mem[byte_offset] << 16) | (mem[(byte_offset + 1) & 0xFFFF] << 8) | mem[(byte_offset + 2) & 0xFFFF]
-                    
-                    for bit in range(24):
-                        pixel_bit = (row_data >> (23 - bit)) & 0x01
-                        
-                        if pixel_bit:
-                            px = screen_left + sprite_x + bit
-                            py = screen_top + sprite_y + row
-                            # Check if pixel is within screen rect bounds
-                            if (self._screen_rect.left <= px < self._screen_rect.right and 
-                                self._screen_rect.top <= py < self._screen_rect.bottom):
-                                self._rgb_frame.put_pixel(px, py, sprite_color)
+                    y_steps = (0, 1) if y_exp else (0,)
+                    for ydup in y_steps:
+                        py = screen_top + sprite_y + row * (2 if y_exp else 1) + ydup
+                        for bit in range(24):
+                            pixel_bit = (row_data >> (23 - bit)) & 0x01
+                            
+                            if pixel_bit:
+                                px0 = screen_left + sprite_x + bit * (2 if x_exp else 1)
+                                if x_exp:
+                                    for xd in range(2):
+                                        px = px0 + xd
+                                        if (self._screen_rect.left <= px < self._screen_rect.right and 
+                                            self._screen_rect.top <= py < self._screen_rect.bottom):
+                                            self._rgb_frame.put_pixel(px, py, sprite_color)
+                                else:
+                                    px = px0
+                                    if (self._screen_rect.left <= px < self._screen_rect.right and 
+                                        self._screen_rect.top <= py < self._screen_rect.bottom):
+                                        self._rgb_frame.put_pixel(px, py, sprite_color)

--- a/graphics.py
+++ b/graphics.py
@@ -1206,6 +1206,22 @@ class PygameInterface:
                 if screen_right < native_w:
                     self._rgb_frame.fill_rect(screen_right, y, native_w - screen_right, 1, c)
 
+    @staticmethod
+    def _vic_fg_opaque_hires_row(row_byte: int) -> Tuple[bool, ...]:
+        """Foreground bits for VIC-II sprite/background priority ($D01B), hires glyph row."""
+        return tuple(bool((row_byte >> (7 - dx)) & 1) for dx in range(8))
+
+    @staticmethod
+    def _vic_fg_opaque_mcm_row(row_byte: int) -> Tuple[bool, ...]:
+        """Opaque (non-transparent 00) pairs for multicolor text/bitmap rows."""
+        o = [False] * 8
+        for pair in range(4):
+            bits = (row_byte >> (6 - pair * 2)) & 0x03
+            op = bits != 0
+            o[pair * 2] = op
+            o[pair * 2 + 1] = op
+        return tuple(o)
+
     def _per_cycle_overlay_sprites_eight_pixels(
         self,
         mem: "MemoryMap",
@@ -1214,12 +1230,16 @@ class PygameInterface:
         y_win: int,
         col: int,
         py: int,
+        fg_opaque: Tuple[bool, ...],
     ) -> None:
         """Draw sprite pixels for one 8-pixel content strip using this column's VIC/CIA2 sample.
 
         Uses the same screen-space mapping as :meth:`_render_sprites` (``y - 50`` / ``x - 24``)
         so sprites line up with the latched path; register values come from the per-cycle grid
         so mid-raster sprite register changes affect the correct column.
+
+        Sprites are composited **7 → 0** (VIC-II: lower index in front). ``fg_opaque`` marks which
+        of the eight column pixels count as opaque foreground for ``$D01B`` sprite-behind-gfx.
         """
         if self._rgb_frame is None:
             return
@@ -1248,9 +1268,13 @@ class PygameInterface:
 
         x0 = col * self.CHAR_WIDTH
 
-        for sprite_num in range(8):
+        sprite_pri = rb(0x1B)
+        fo = fg_opaque if len(fg_opaque) == 8 else ((False,) * 8)
+
+        for sprite_num in range(7, -1, -1):
             if not (rb(0x15) & (1 << sprite_num)):
                 continue
+            behind_gfx = (sprite_pri >> sprite_num) & 1
             y_vic = rb(sprite_num * 2 + 1)
             # Same as _render_sprites: py = screen_top + (y_vic - 50) + row  →  row = y_win - y_vic + 50
             row = y_win - y_vic + 50
@@ -1271,6 +1295,8 @@ class PygameInterface:
 
             if multicolor:
                 for dx in range(8):
+                    if behind_gfx and fo[dx]:
+                        continue
                     cx = x0 + dx
                     rel_x = cx - sprite_x
                     if rel_x < 0 or rel_x >= 24:
@@ -1293,6 +1319,8 @@ class PygameInterface:
                         buf[i + 2] = b
             else:
                 for dx in range(8):
+                    if behind_gfx and fo[dx]:
+                        continue
                     cx = x0 + dx
                     rel_x = cx - sprite_x
                     if rel_x < 0 or rel_x >= 24:
@@ -1461,7 +1489,13 @@ class PygameInterface:
                         color_mem,
                     )
                     if not skip_sprites:
-                        self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
+                        if mode_info.get("multicolor"):
+                            fg_op = self._vic_fg_opaque_mcm_row(byte)
+                        else:
+                            fg_op = self._vic_fg_opaque_hires_row(byte)
+                        self._per_cycle_overlay_sprites_eight_pixels(
+                            mem, regb, pra, y_win, col, py, fg_op
+                        )
                     continue
 
                 char_base = mode_info["char_base"]
@@ -1477,14 +1511,16 @@ class PygameInterface:
                     char_bg = self._palette.get(bg_colors[bg_index], (0, 0, 0))
                     self._rgb_frame.fill_rect(x, py, self.CHAR_WIDTH, 1, char_bg)
                     row_bytes = self._fetch_glyph_rows(vic_bank, char_base, code_ecm)
-                    self._plot_hires_text_scanline(x, py, row_bytes[scan], color_code)
+                    row_byte_text = row_bytes[scan]
+                    self._plot_hires_text_scanline(x, py, row_byte_text, color_code)
                 else:
                     row_bytes = self._fetch_glyph_rows(vic_bank, char_base, raw_code)
+                    row_byte_text = row_bytes[scan]
                     if multicolor_text and (color_code & 0x08):
                         self._plot_mcm_text_scanline(
                             x,
                             py,
-                            row_bytes[scan],
+                            row_byte_text,
                             color_code & 0x07,
                             bg_colors[0],
                             bg_colors[1],
@@ -1492,10 +1528,18 @@ class PygameInterface:
                         )
                     else:
                         fg = (color_code & 0x07) if multicolor_text else color_code
-                        self._plot_hires_text_scanline(x, py, row_bytes[scan], fg)
+                        self._plot_hires_text_scanline(x, py, row_byte_text, fg)
 
                 if not skip_sprites:
-                    self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
+                    if extended_color:
+                        fg_op = self._vic_fg_opaque_hires_row(row_byte_text)
+                    elif multicolor_text and (color_code & 0x08):
+                        fg_op = self._vic_fg_opaque_mcm_row(row_byte_text)
+                    else:
+                        fg_op = self._vic_fg_opaque_hires_row(row_byte_text)
+                    self._per_cycle_overlay_sprites_eight_pixels(
+                        mem, regb, pra, y_win, col, py, fg_op
+                    )
 
         if mem.vic_render_snapshots:
             mem.snapshot_vic_render_state()
@@ -1852,8 +1896,8 @@ class PygameInterface:
             sprite_mc0 = self.emulator.memory.read(0xD025) & 0x0F
             sprite_mc1 = self.emulator.memory.read(0xD026) & 0x0F
         
-        # Render sprites 0-7 (back to front)
-        for sprite_num in range(8):
+        # Render sprites 7→0 so lower-numbered sprites appear in front (VIC-II order).
+        for sprite_num in range(7, -1, -1):
             sprite_data = self.emulator.memory.get_sprite_data(sprite_num, for_render=True)
             
             if not sprite_data['enabled']:

--- a/graphics.py
+++ b/graphics.py
@@ -1194,9 +1194,9 @@ class PygameInterface:
     def _render_frame_per_cycle(self) -> None:
         """Per-cycle video: VIC/CIA2 samples on a 40×200 grid (see ``video_beam.per_cycle_geometry``).
 
-        Text modes (hires, multicolor, ECM) use the sampled registers per character column
-        and scanline. Bitmap modes are not composited here yet — falls back to the latched
-        path. Sprites use the same end-of-frame latch as :meth:`_render_frame_beam`.
+        Text modes (hires, multicolor, ECM) and **bitmap** (hires / multicolor) use the sampled
+        registers per character column and scanline. Sprites use the same end-of-frame latch
+        as :meth:`_render_frame_beam`.
         """
         from .video_beam import content_row_to_raster_line, per_cycle_geometry
 
@@ -1215,12 +1215,6 @@ class PygameInterface:
         vs = mem.video_standard
         geom = per_cycle_geometry(vs)
         flat_mv = memoryview(flat)
-        mode0 = mem._display_mode_from_vic_bytes(flat_mv[0:64])
-        if mode0["bitmap_mode"]:
-            if mem.vic_render_snapshots:
-                mem.snapshot_vic_render_state()
-            self._render_frame_latched()
-            return
 
         nlines = geom.raster_lines
         total_lines = nlines
@@ -1300,11 +1294,29 @@ class PygameInterface:
                     regb[0x24] & 0x0F,
                 ]
                 screen_base = (vic_bank + mode_info["screen_base"]) & 0xFFFF
-                char_base = mode_info["char_base"]
-                idx_scr = text_row * self.SCREEN_COLS + col
-                raw_code = ram[(screen_base + idx_scr) & 0xFFFF]
-                color_code = ram[COLOR_MEM + idx_scr] & 0x0F
+                bitmap_base = (vic_bank + mode_info["bitmap_base"]) & 0xFFFF
                 x = screen_left + col * self.CHAR_WIDTH
+                char_index = text_row * self.SCREEN_COLS + col
+
+                if mode_info["bitmap_mode"]:
+                    color_data = ram[(screen_base + char_index) & 0xFFFF]
+                    color_mem = ram[COLOR_MEM + char_index] & 0x0F
+                    bitmap_offset = char_index * 8
+                    byte = ram[(bitmap_base + bitmap_offset + scan) & 0xFFFF]
+                    self._plot_bitmap_scanline(
+                        x,
+                        py,
+                        byte,
+                        bool(mode_info.get("multicolor")),
+                        bg_colors[0],
+                        color_data,
+                        color_mem,
+                    )
+                    continue
+
+                char_base = mode_info["char_base"]
+                raw_code = ram[(screen_base + char_index) & 0xFFFF]
+                color_code = ram[COLOR_MEM + char_index] & 0x0F
 
                 extended_color = bool(mode_info.get("extended_color", False))
                 multicolor_text = bool(mode_info.get("multicolor")) and not extended_color
@@ -1592,34 +1604,46 @@ class PygameInterface:
             color_mem = mem[COLOR_MEM + char_index] & 0x0F
             bitmap_offset = char_index * 8
             base_x = screen_left + col * 8
-            if multicolor:
-                color1 = (color_data >> 4) & 0x0F
-                color2 = color_data & 0x0F
-                color3 = color_mem
-                for r in range(8):
-                    byte = mem[(bitmap_base + bitmap_offset + r) & 0xFFFF]
-                    yy = y + r
-                    for bit_pair in range(4):
-                        pixel_bits = (byte >> (6 - bit_pair * 2)) & 0x03
-                        if pixel_bits == 0:
-                            c = self._palette.get(bg0_color_idx, (0, 0, 0))
-                        elif pixel_bits == 1:
-                            c = self._palette.get(color1, (0, 0, 0))
-                        elif pixel_bits == 2:
-                            c = self._palette.get(color2, (0, 0, 0))
-                        else:
-                            c = self._palette.get(color3, (0, 0, 0))
-                        self._rgb_frame.fill_rect(base_x + bit_pair * 2, yy, 2, 1, c)
-            else:
-                color1 = (color_data >> 4) & 0x0F
-                color0 = color_data & 0x0F
-                for r in range(8):
-                    byte = mem[(bitmap_base + bitmap_offset + r) & 0xFFFF]
-                    yy = y + r
-                    for bit in range(8):
-                        pixel_bit = (byte >> (7 - bit)) & 0x01
-                        c = self._palette.get(color1 if pixel_bit else color0, (0, 0, 0))
-                        self._rgb_frame.put_pixel(base_x + bit, yy, c)
+            for r in range(8):
+                byte = mem[(bitmap_base + bitmap_offset + r) & 0xFFFF]
+                yy = y + r
+                self._plot_bitmap_scanline(
+                    base_x, yy, byte, multicolor, bg0_color_idx, color_data, color_mem
+                )
+
+    def _plot_bitmap_scanline(
+        self,
+        base_x: int,
+        yy: int,
+        byte: int,
+        multicolor: bool,
+        bg0_color_idx: int,
+        color_data: int,
+        color_mem: int,
+    ) -> None:
+        """Draw one 8-pixel row of a bitmap 8×8 cell (hi-res or multicolor)."""
+        if multicolor:
+            color1 = (color_data >> 4) & 0x0F
+            color2 = color_data & 0x0F
+            color3 = color_mem
+            for bit_pair in range(4):
+                pixel_bits = (byte >> (6 - bit_pair * 2)) & 0x03
+                if pixel_bits == 0:
+                    c = self._palette.get(bg0_color_idx, (0, 0, 0))
+                elif pixel_bits == 1:
+                    c = self._palette.get(color1, (0, 0, 0))
+                elif pixel_bits == 2:
+                    c = self._palette.get(color2, (0, 0, 0))
+                else:
+                    c = self._palette.get(color3, (0, 0, 0))
+                self._rgb_frame.fill_rect(base_x + bit_pair * 2, yy, 2, 1, c)
+        else:
+            color1 = (color_data >> 4) & 0x0F
+            color0 = color_data & 0x0F
+            for bit in range(8):
+                pixel_bit = (byte >> (7 - bit)) & 0x01
+                c = self._palette.get(color1 if pixel_bit else color0, (0, 0, 0))
+                self._rgb_frame.put_pixel(base_x + bit, yy, c)
 
     def _render_bitmap_mode(self, mode_info: dict, snap: Optional[Tuple[bytes, int]] = None) -> None:
         """Render bitmap mode (standard or multicolor); wrapper over per-row helper."""

--- a/graphics.py
+++ b/graphics.py
@@ -870,16 +870,26 @@ class PygameInterface:
     def _fetch_glyph_rows(self, vic_bank_base: int, char_base: int, screen_code: int) -> bytes:
         """Read 8 bytes of charset definition as the VIC-II fetches (incl. ROM mirror at bank+$1000)."""
         code = screen_code & 0xFF
-        key = (vic_bank_base, char_base, code)
-        cache = self._glyph_rows_cache
-        hit = cache.get(key)
-        if hit is not None:
-            cache.move_to_end(key)
-            return hit
-        row = self.emulator.memory.read_vic_charset_glyph_rows(vic_bank_base, char_base, code)
-        cache[key] = row
-        if len(cache) > self._glyph_rows_cache_max:
-            cache.popitem(last=False)
+        mem = self.emulator.memory
+        cacheable = mem.char_rom is not None
+        if cacheable:
+            for r in range(8):
+                rel = (char_base + code * 8 + r) & 0x3FFF
+                if not mem.vic_fetches_charset_rom(vic_bank_base, rel):
+                    cacheable = False
+                    break
+        if cacheable:
+            key = (vic_bank_base, char_base, code)
+            cache = self._glyph_rows_cache
+            hit = cache.get(key)
+            if hit is not None:
+                cache.move_to_end(key)
+                return hit
+        row = mem.read_vic_charset_glyph_rows(vic_bank_base, char_base, code)
+        if cacheable:
+            cache[key] = row
+            if len(cache) > self._glyph_rows_cache_max:
+                cache.popitem(last=False)
         return row
 
     def _plot_hires_text_cell(self, x: int, y: int, rows: bytes, fg_idx: int) -> None:

--- a/graphics.py
+++ b/graphics.py
@@ -1347,6 +1347,38 @@ class PygameInterface:
         screen_h = int(self._screen_rect.height)
         screen_right = screen_left + screen_w
 
+        use_rust_draw = (
+            os.environ.get("C64PY_RUST_COMPOSITE", "1").strip().lower()
+            not in ("0", "no", "false", "off")
+        )
+        if use_rust_draw:
+            try:
+                from . import _core
+                if _core.is_available:
+                    pal48 = bytearray(48)
+                    for i in range(16):
+                        r, g, b = self._palette.get(i, (0, 0, 0))
+                        pal48[i * 3] = r
+                        pal48[i * 3 + 1] = g
+                        pal48[i * 3 + 2] = b
+                    _core.composite_per_cycle_frame(
+                        mem,
+                        bytes(pal48),
+                        self._rgb_frame._buf,
+                        video_standard=str(vs),
+                        native_width=native_w,
+                        native_height=native_h,
+                        screen_left=screen_left,
+                        screen_top=screen_top,
+                        screen_width=screen_w,
+                        screen_height=screen_h,
+                        border_px=border_px,
+                        skip_sprites=skip_sprites,
+                    )
+                    return
+            except (RuntimeError, ValueError, TypeError, AttributeError):
+                pass
+
         def _border_regb_for_rl(rl: int) -> memoryview:
             rl %= nlines
             y_win = rl - geom.content_first_raster

--- a/graphics.py
+++ b/graphics.py
@@ -4,6 +4,8 @@ Pygame graphics interface for the C64 emulator.
 
 from __future__ import annotations
 
+from collections import OrderedDict
+
 import os
 import re
 import sys
@@ -121,6 +123,10 @@ class PygameInterface:
         # Standard hires text when RAM charset matches char ROM: pygame blit (built once per ROM+offset).
         self._rom_glyph_key: Optional[Tuple[int, int]] = None  # (id(char_rom), rom_offset)
         self._rom_glyph_surfaces: Optional[list] = None
+        # Charset row cache (vic bank, char base, screen code) → 8 glyph bytes; bounded LRU.
+        # Speeds per-cycle compositing (8000 cells/frame) when the same codes repeat (e.g. BASIC boot).
+        self._glyph_rows_cache: OrderedDict[tuple[int, int, int], bytes] = OrderedDict()
+        self._glyph_rows_cache_max: int = 8192
 
         self._palette = {
             0: (0, 0, 0),
@@ -863,9 +869,18 @@ class PygameInterface:
 
     def _fetch_glyph_rows(self, vic_bank_base: int, char_base: int, screen_code: int) -> bytes:
         """Read 8 bytes of charset definition as the VIC-II fetches (incl. ROM mirror at bank+$1000)."""
-        return self.emulator.memory.read_vic_charset_glyph_rows(
-            vic_bank_base, char_base, screen_code & 0xFF
-        )
+        code = screen_code & 0xFF
+        key = (vic_bank_base, char_base, code)
+        cache = self._glyph_rows_cache
+        hit = cache.get(key)
+        if hit is not None:
+            cache.move_to_end(key)
+            return hit
+        row = self.emulator.memory.read_vic_charset_glyph_rows(vic_bank_base, char_base, code)
+        cache[key] = row
+        if len(cache) > self._glyph_rows_cache_max:
+            cache.popitem(last=False)
+        return row
 
     def _plot_hires_text_cell(self, x: int, y: int, rows: bytes, fg_idx: int) -> None:
         """Draw an 8×8 hires glyph; unset bits leave the existing background."""
@@ -1315,6 +1330,7 @@ class PygameInterface:
         vs = mem.video_standard
         geom = per_cycle_geometry(vs)
         flat_mv = memoryview(flat)
+        skip_sprites = _env_truthy("C64PY_PER_CYCLE_NO_SPRITES")
 
         nlines = geom.raster_lines
         total_lines = nlines
@@ -1412,7 +1428,8 @@ class PygameInterface:
                         color_data,
                         color_mem,
                     )
-                    self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
+                    if not skip_sprites:
+                        self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
                     continue
 
                 char_base = mode_info["char_base"]
@@ -1445,7 +1462,8 @@ class PygameInterface:
                         fg = (color_code & 0x07) if multicolor_text else color_code
                         self._plot_hires_text_scanline(x, py, row_bytes[scan], fg)
 
-                self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
+                if not skip_sprites:
+                    self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
 
         if mem.vic_render_snapshots:
             mem.snapshot_vic_render_state()

--- a/graphics.py
+++ b/graphics.py
@@ -1050,10 +1050,10 @@ class PygameInterface:
 
         Background (text/bitmap) uses one VIC/CIA2 sample per 8-line content row.
         Sprites are composited **once** after all rows using the same frame latch
-        as :meth:`_render_frame_latched` (see :meth:`_render_sprites`). Per-row
-        sprite DMA (raster multiplex within a band) needs the future per-cycle
-        tier; sampling sprite regs only at each band start mis-draws games such
-        as Arkanoid.
+        as :meth:`_render_frame_latched` (see :meth:`_render_sprites`). Raster
+        multiplex that changes sprite registers between character columns is better
+        reproduced with **`--video-rendering per-cycle`**, which samples sprite regs
+        per column; the beam path still latches sprites once per frame.
 
         Per-line data comes from :meth:`MemoryMap.beam_capture_raster_line`
         during Python CPU steps and from the Rust fast batch when beam
@@ -1191,12 +1191,112 @@ class PygameInterface:
                 if screen_right < native_w:
                     self._rgb_frame.fill_rect(screen_right, y, native_w - screen_right, 1, c)
 
+    def _per_cycle_overlay_sprites_eight_pixels(
+        self,
+        mem: "MemoryMap",
+        regb: memoryview,
+        pra: int,
+        y_win: int,
+        col: int,
+        py: int,
+    ) -> None:
+        """Draw sprite pixels for one 8-pixel content strip using this column's VIC/CIA2 sample.
+
+        Uses the same screen-space mapping as :meth:`_render_sprites` (``y - 50`` / ``x - 24``)
+        so sprites line up with the latched path; register values come from the per-cycle grid
+        so mid-raster sprite register changes affect the correct column.
+        """
+        if self._rgb_frame is None:
+            return
+
+        def rb(i: int) -> int:
+            return int(regb[i]) if i < len(regb) else 0
+
+        ram = mem.ram
+        vic_bank = (3 - (int(pra) & 0x03)) * 0x4000
+        mode_info = mem._display_mode_from_vic_bytes(regb)
+        screen_base = int(mode_info["screen_base"])
+        matrix = (vic_bank + screen_base) & 0xFFFF
+
+        buf = self._rgb_frame._buf
+        w = self._rgb_frame.width
+        screen_left = int(self._screen_rect.left)
+        sl = int(self._screen_rect.left)
+        sr = int(self._screen_rect.right)
+        st = int(self._screen_rect.top)
+        sb = int(self._screen_rect.bottom)
+
+        mc0 = self._palette.get(rb(0x25) & 0x0F, (0, 0, 0))
+        mc1 = self._palette.get(rb(0x26) & 0x0F, (0, 0, 0))
+        mcr0, mcg0, mcb0 = mc0
+        mcr1, mcg1, mcb1 = mc1
+
+        x0 = col * self.CHAR_WIDTH
+
+        for sprite_num in range(8):
+            if not (rb(0x15) & (1 << sprite_num)):
+                continue
+            y_vic = rb(sprite_num * 2 + 1)
+            # Same as _render_sprites: py = screen_top + (y_vic - 50) + row  →  row = y_win - y_vic + 50
+            row = y_win - y_vic + 50
+            if row < 0 or row >= 21:
+                continue
+
+            x_vic = rb(sprite_num * 2) + (256 if (rb(0x10) & (1 << sprite_num)) else 0)
+            sprite_x = x_vic - 24
+            multicolor = (rb(0x1C) & (1 << sprite_num)) != 0
+            sp_idx = rb(0x27 + sprite_num) & 0x0F
+            sp = self._palette.get(sp_idx, (255, 255, 255))
+            spr, spg, spb = sp
+
+            ptr = ram[(matrix + 0x3F8 + sprite_num) & 0xFFFF]
+            sprite_addr = (vic_bank + ((ptr & 0xFF) << 6)) & 0xFFFF
+            bo = (sprite_addr + row * 3) & 0xFFFF
+            row_data = (ram[bo] << 16) | (ram[(bo + 1) & 0xFFFF] << 8) | ram[(bo + 2) & 0xFFFF]
+
+            if multicolor:
+                for dx in range(8):
+                    cx = x0 + dx
+                    rel_x = cx - sprite_x
+                    if rel_x < 0 or rel_x >= 24:
+                        continue
+                    bp = rel_x // 2
+                    bits = (row_data >> (22 - bp * 2)) & 0x03
+                    if bits == 0:
+                        continue
+                    if bits == 1:
+                        r, g, b = mcr0, mcg0, mcb0
+                    elif bits == 2:
+                        r, g, b = spr, spg, spb
+                    else:
+                        r, g, b = mcr1, mcg1, mcb1
+                    px = screen_left + cx
+                    if sl <= px < sr and st <= py < sb:
+                        i = (py * w + px) * 3
+                        buf[i] = r
+                        buf[i + 1] = g
+                        buf[i + 2] = b
+            else:
+                for dx in range(8):
+                    cx = x0 + dx
+                    rel_x = cx - sprite_x
+                    if rel_x < 0 or rel_x >= 24:
+                        continue
+                    if not ((row_data >> (23 - rel_x)) & 0x01):
+                        continue
+                    px = screen_left + cx
+                    if sl <= px < sr and st <= py < sb:
+                        i = (py * w + px) * 3
+                        buf[i] = spr
+                        buf[i + 1] = spg
+                        buf[i + 2] = spb
+
     def _render_frame_per_cycle(self) -> None:
         """Per-cycle video: VIC/CIA2 samples on a 40×200 grid (see ``video_beam.per_cycle_geometry``).
 
         Text modes (hires, multicolor, ECM) and **bitmap** (hires / multicolor) use the sampled
-        registers per character column and scanline. Sprites use the same end-of-frame latch
-        as :meth:`_render_frame_beam`.
+        registers per character column and scanline. **Sprites** use the same per-column samples
+        (mid-raster moves and multiplexing) instead of the end-of-frame latch.
         """
         from .video_beam import content_row_to_raster_line, per_cycle_geometry
 
@@ -1312,6 +1412,7 @@ class PygameInterface:
                         color_data,
                         color_mem,
                     )
+                    self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
                     continue
 
                 char_base = mode_info["char_base"]
@@ -1344,9 +1445,10 @@ class PygameInterface:
                         fg = (color_code & 0x07) if multicolor_text else color_code
                         self._plot_hires_text_scanline(x, py, row_bytes[scan], fg)
 
+                self._per_cycle_overlay_sprites_eight_pixels(mem, regb, pra, y_win, col, py)
+
         if mem.vic_render_snapshots:
             mem.snapshot_vic_render_state()
-        self._render_sprites(getattr(mem, "_vic_render_snapshot", None))
 
     def _render_frame(self) -> None:
         """Render one frame into the back buffer (per-cycle, beam, or latched)."""
@@ -1640,10 +1742,30 @@ class PygameInterface:
         else:
             color1 = (color_data >> 4) & 0x0F
             color0 = color_data & 0x0F
+            c0 = self._palette.get(color0, (0, 0, 0))
+            c1 = self._palette.get(color1, (0, 0, 0))
+            buf = self._rgb_frame._buf
+            w = self._rgb_frame.width
+            h = self._rgb_frame.height
+            if not (0 <= yy < h):
+                return
+            r0, g0, b0 = c0
+            r1, g1, b1 = c1
+            base_row = yy * w * 3
             for bit in range(8):
-                pixel_bit = (byte >> (7 - bit)) & 0x01
-                c = self._palette.get(color1 if pixel_bit else color0, (0, 0, 0))
-                self._rgb_frame.put_pixel(base_x + bit, yy, c)
+                px = base_x + bit
+                if not (0 <= px < w):
+                    continue
+                if (byte >> (7 - bit)) & 0x01:
+                    i = base_row + px * 3
+                    buf[i] = r1
+                    buf[i + 1] = g1
+                    buf[i + 2] = b1
+                else:
+                    i = base_row + px * 3
+                    buf[i] = r0
+                    buf[i + 1] = g0
+                    buf[i + 2] = b0
 
     def _render_bitmap_mode(self, mode_info: dict, snap: Optional[Tuple[bytes, int]] = None) -> None:
         """Render bitmap mode (standard or multicolor); wrapper over per-row helper."""

--- a/memory.py
+++ b/memory.py
@@ -94,12 +94,14 @@ class MemoryMap:
     # True after buffers are filled from current VIC shadow (avoids an all-black first frame).
     beam_snapshots_primed: bool = False
     # Future per-cycle video tier: one VIC/CIA2 snapshot per visible character cycle.
+    # Authoritative storage is the flat bytearrays below (renderers and Rust read those).
     per_cycle_render_enabled: bool = False
-    per_cycle_vic_samples: Optional[List[bytes]] = None
-    per_cycle_cia2_samples: Optional[List[int]] = None
     per_cycle_vic_flat: Optional[bytearray] = None
     per_cycle_cia2_flat: Optional[bytearray] = None
     per_cycle_snapshots_primed: bool = False
+    # Lazily rebuilt when ``video_standard`` changes (``per_cycle_geometry``).
+    _per_cycle_geom_vs: Optional[str] = field(default=None, init=False, repr=False)
+    _per_cycle_geom_obj: Optional[object] = field(default=None, init=False, repr=False)
     # Optional :class:`~c64py.iec_kernal_bridge.KernalIecTap` when TCP drives need KERNAL line tracing.
     iec_kernal_tap: Optional[object] = field(default=None, repr=False)
     # Cached 6510 $01 effective value for MemoryMap.read() hot path (invalidated on $00/$01 writes).
@@ -751,23 +753,25 @@ class MemoryMap:
             self.beam_cia2_flat = bytearray(n)
             self.beam_snapshots_primed = False
 
+    def _per_cycle_geom_cached(self):
+        """Return :class:`~c64py.video_beam.VicPerCycleGeometry` for ``video_standard`` (cached)."""
+        vs = self.video_standard
+        if self._per_cycle_geom_vs != vs or self._per_cycle_geom_obj is None:
+            self._per_cycle_geom_vs = vs
+            self._per_cycle_geom_obj = per_cycle_geometry(vs)
+        return self._per_cycle_geom_obj
+
     def ensure_per_cycle_buffers(self) -> None:
         """Allocate per-cycle VIC/CIA2 snapshot arrays for the visible content window."""
-        geom = per_cycle_geometry(self.video_standard)
+        geom = self._per_cycle_geom_cached()
         n = geom.visible_sample_count
         need = (
-            self.per_cycle_vic_samples is None
-            or len(self.per_cycle_vic_samples) != n
-            or self.per_cycle_cia2_samples is None
-            or len(self.per_cycle_cia2_samples) != n
-            or self.per_cycle_vic_flat is None
+            self.per_cycle_vic_flat is None
             or len(self.per_cycle_vic_flat) != n * 64
             or self.per_cycle_cia2_flat is None
             or len(self.per_cycle_cia2_flat) != n
         )
         if need:
-            self.per_cycle_vic_samples = [bytes(64) for _ in range(n)]
-            self.per_cycle_cia2_samples = [0] * n
             self.per_cycle_vic_flat = bytearray(n * 64)
             self.per_cycle_cia2_flat = bytearray(n)
             self.per_cycle_snapshots_primed = False
@@ -777,16 +781,13 @@ class MemoryMap:
         if not self.per_cycle_render_enabled:
             return
         self.ensure_per_cycle_buffers()
-        assert self.per_cycle_vic_samples is not None and self.per_cycle_cia2_samples is not None
         assert self.per_cycle_vic_flat is not None and self.per_cycle_cia2_flat is not None
         snap = bytes(self._vic_regs[:0x40])
         pra = self.cia2_pra & 0xFF
-        for i in range(len(self.per_cycle_vic_samples)):
-            self.per_cycle_vic_samples[i] = snap
-            self.per_cycle_cia2_samples[i] = pra
-            o = i * 64
-            self.per_cycle_vic_flat[o : o + 64] = snap
-            self.per_cycle_cia2_flat[i] = pra
+        n = len(self.per_cycle_cia2_flat)
+        # One bulk write avoids 8000 tight Python loops at startup.
+        self.per_cycle_vic_flat[:] = snap * n
+        self.per_cycle_cia2_flat[:] = bytes((pra & 0xFF,) * n)
         self.per_cycle_snapshots_primed = True
 
     def prime_beam_snapshots_from_current_vic(self) -> None:
@@ -833,20 +834,17 @@ class MemoryMap:
         """
         if not self.per_cycle_render_enabled:
             return
-        geom = per_cycle_geometry(self.video_standard)
+        geom = self._per_cycle_geom_cached()
         idx = geom.sample_index(self.raster_line, self.raster_cycles)
         if idx is None:
             return
         self.ensure_per_cycle_buffers()
         assert self.per_cycle_vic_flat is not None and self.per_cycle_cia2_flat is not None
-        assert self.per_cycle_vic_samples is not None
         vic_slice = self._vic_regs[:0x40]
         pr = self.cia2_pra & 0xFF
         o = idx * 64
         self.per_cycle_vic_flat[o : o + 64] = vic_slice
         self.per_cycle_cia2_flat[idx] = pr
-        self.per_cycle_vic_samples[idx] = bytes(vic_slice)
-        self.per_cycle_cia2_samples[idx] = pr
 
     def _read_cia2(self, reg: int) -> int:
         """Read CIA2 register.

--- a/memory.py
+++ b/memory.py
@@ -15,6 +15,7 @@ from .constants import (
     VIC_D011_BMM, VIC_D011_ECM, VIC_D016_MCM
 )
 from .cpu_state import CIATimer
+from .video_beam import per_cycle_geometry
 
 if TYPE_CHECKING:
     from .debug import UdpDebugLogger
@@ -92,6 +93,13 @@ class MemoryMap:
     beam_cia2_flat: Optional[bytearray] = None
     # True after buffers are filled from current VIC shadow (avoids an all-black first frame).
     beam_snapshots_primed: bool = False
+    # Future per-cycle video tier: one VIC/CIA2 snapshot per visible character cycle.
+    per_cycle_render_enabled: bool = False
+    per_cycle_vic_samples: Optional[List[bytes]] = None
+    per_cycle_cia2_samples: Optional[List[int]] = None
+    per_cycle_vic_flat: Optional[bytearray] = None
+    per_cycle_cia2_flat: Optional[bytearray] = None
+    per_cycle_snapshots_primed: bool = False
     # Optional :class:`~c64py.iec_kernal_bridge.KernalIecTap` when TCP drives need KERNAL line tracing.
     iec_kernal_tap: Optional[object] = field(default=None, repr=False)
     # Cached 6510 $01 effective value for MemoryMap.read() hot path (invalidated on $00/$01 writes).
@@ -742,6 +750,44 @@ class MemoryMap:
             self.beam_vic_flat = bytearray(n * 64)
             self.beam_cia2_flat = bytearray(n)
             self.beam_snapshots_primed = False
+
+    def ensure_per_cycle_buffers(self) -> None:
+        """Allocate per-cycle VIC/CIA2 snapshot arrays for the visible content window."""
+        geom = per_cycle_geometry(self.video_standard)
+        n = geom.visible_sample_count
+        need = (
+            self.per_cycle_vic_samples is None
+            or len(self.per_cycle_vic_samples) != n
+            or self.per_cycle_cia2_samples is None
+            or len(self.per_cycle_cia2_samples) != n
+            or self.per_cycle_vic_flat is None
+            or len(self.per_cycle_vic_flat) != n * 64
+            or self.per_cycle_cia2_flat is None
+            or len(self.per_cycle_cia2_flat) != n
+        )
+        if need:
+            self.per_cycle_vic_samples = [bytes(64) for _ in range(n)]
+            self.per_cycle_cia2_samples = [0] * n
+            self.per_cycle_vic_flat = bytearray(n * 64)
+            self.per_cycle_cia2_flat = bytearray(n)
+            self.per_cycle_snapshots_primed = False
+
+    def prime_per_cycle_snapshots_from_current_vic(self) -> None:
+        """Copy current VIC/CIA2 PA into every per-cycle sample slot."""
+        if not self.per_cycle_render_enabled:
+            return
+        self.ensure_per_cycle_buffers()
+        assert self.per_cycle_vic_samples is not None and self.per_cycle_cia2_samples is not None
+        assert self.per_cycle_vic_flat is not None and self.per_cycle_cia2_flat is not None
+        snap = bytes(self._vic_regs[:0x40])
+        pra = self.cia2_pra & 0xFF
+        for i in range(len(self.per_cycle_vic_samples)):
+            self.per_cycle_vic_samples[i] = snap
+            self.per_cycle_cia2_samples[i] = pra
+            o = i * 64
+            self.per_cycle_vic_flat[o : o + 64] = snap
+            self.per_cycle_cia2_flat[i] = pra
+        self.per_cycle_snapshots_primed = True
 
     def prime_beam_snapshots_from_current_vic(self) -> None:
         """Copy current VIC/CIA2 PA into every raster line (baseline before per-line capture)."""

--- a/memory.py
+++ b/memory.py
@@ -824,6 +824,30 @@ class MemoryMap:
         self.beam_cia2_flat[line] = pr
         self.beam_snapshots_primed = True
 
+    def per_cycle_capture_vic_sample(self) -> None:
+        """Record VIC + CIA2 PA at the current raster line/cycle when inside the visible window.
+
+        Intended to run once per emulated VIC cycle from :meth:`cpu.CPU6502._vic_tick_one`
+        after ``raster_line`` / ``raster_cycles`` are updated. When ``per_cycle_render_enabled``
+        is false, this is a no-op. Fast VIC (coarse raster) mode never calls this.
+        """
+        if not self.per_cycle_render_enabled:
+            return
+        geom = per_cycle_geometry(self.video_standard)
+        idx = geom.sample_index(self.raster_line, self.raster_cycles)
+        if idx is None:
+            return
+        self.ensure_per_cycle_buffers()
+        assert self.per_cycle_vic_flat is not None and self.per_cycle_cia2_flat is not None
+        assert self.per_cycle_vic_samples is not None
+        vic_slice = self._vic_regs[:0x40]
+        pr = self.cia2_pra & 0xFF
+        o = idx * 64
+        self.per_cycle_vic_flat[o : o + 64] = vic_slice
+        self.per_cycle_cia2_flat[idx] = pr
+        self.per_cycle_vic_samples[idx] = bytes(vic_slice)
+        self.per_cycle_cia2_samples[idx] = pr
+
     def _read_cia2(self, reg: int) -> int:
         """Read CIA2 register.
         

--- a/presenter.py
+++ b/presenter.py
@@ -63,6 +63,13 @@ class RgbFrameBuffer:
         r, g, b = rgb
         buf = self._buf
         w = self.width
+        # Hot path: single pixel (hires sprites / bitmap scanlines).
+        if rw == 1 and rh == 1 and x0 == x and y0 == y and x1 - x0 == 1 and y1 - y0 == 1:
+            i = (y0 * w + x0) * 3
+            buf[i] = r
+            buf[i + 1] = g
+            buf[i + 2] = b
+            return
         # Hot path: double-wide pixels (multicolor bitmap / MCM text / MC sprites).
         # Avoid per-call bytes() allocation (tens of thousands/frame in swinth-like demos).
         if rw == 2 and rh == 1 and x1 - x0 == 2 and y1 - y0 == 1:

--- a/resid.py
+++ b/resid.py
@@ -32,6 +32,10 @@ controls the minimum gap between lines. A final summary line is printed on ``clo
 when tracing is enabled. Use ``ReSIDEmulator.get_resid_audio_stats()`` for live totals
 without stderr noise.
 
+Optional ``C64PY_RESID_MAX_PENDING_SEC`` (default ``0.35``): when the lockstep PCM queue
+exceeds this many seconds of mono int16 audio, the emulator CPU thread sleeps briefly so
+playback does not drift seconds behind the game (see ``C64Emulator._resid_audio_backpressure_if_needed``).
+
 WAV capture (same PCM as pygame)
 ----------------------------------
 Set ``C64PY_RESID_WAV`` to a filesystem path (e.g. ``/tmp/c64_resid.wav``). Every mixer

--- a/rust/c64py-core/src/c64_fast.rs
+++ b/rust/c64py-core/src/c64_fast.rs
@@ -120,7 +120,7 @@ fn dispatch_irq_hybrid(
     cpu: &mut CpuState,
     mem: &mut C64MemoryMap<'_>,
     eng: &mut ViciiEngine,
-    _resid: Option<&mut ResidSession>,
+    resid: &mut Option<&mut ResidSession>,
     total_cyc: &mut u64,
 ) {
     mem.pending_irq = false;
@@ -129,17 +129,16 @@ fn dispatch_irq_hybrid(
     let pcl = pc as u8;
     let status = (cpu.p | 0x20) & !0x10; // B clear, bit 5 set
 
-    // Per-phase tick: advance VIC, stall on READ if ba_blocks_cpu.
-    // resid is passed as None here — 7-cycle drift is negligible for reSID sync.
+    // Per-phase tick: advance VIC + reSID (same as Python ``_handle_irq`` / ``_irq_cycle``).
     macro_rules! tick_phase {
         (READ) => {
             loop {
-                let (_, ba_blocks_cpu) = tick_one_cycle(eng, mem, cpu, None, total_cyc);
+                let (_, ba_blocks_cpu) = tick_one_cycle(eng, mem, cpu, resid, total_cyc);
                 if !ba_blocks_cpu { break; }
             }
         };
         (WRITE) => {
-            tick_one_cycle(eng, mem, cpu, None, total_cyc);
+            tick_one_cycle(eng, mem, cpu, resid, total_cyc);
         };
     }
 
@@ -171,12 +170,12 @@ fn coarse_cycles(
     cpu: &mut CpuState,
     mem: &mut C64MemoryMap<'_>,
     c: u32,
-    resid: Option<&mut ResidSession>,
+    resid: &mut Option<&mut ResidSession>,
 ) {
     advance_raster(mem, c);
     cpu.cycles = cpu.cycles.wrapping_add(u64::from(c));
     update_cia_timers(mem, c, false);
-    if let Some(r) = resid {
+    if let Some(r) = resid.as_mut() {
         r.clock_cycles(c as i32);
     }
     service_irq_if_any(cpu, mem);
@@ -343,7 +342,7 @@ fn tick_one_cycle(
     eng: &mut ViciiEngine,
     mem: &mut C64MemoryMap<'_>,
     cpu: &mut CpuState,
-    resid: Option<&mut ResidSession>,
+    resid: &mut Option<&mut ResidSession>,
     total_cyc: &mut u64,
 ) -> (bool, bool) {
     let (irq_edge, ba_blocks_cpu) = eng.step(mem);
@@ -353,7 +352,7 @@ fn tick_one_cycle(
     }
     cpu.cycles = cpu.cycles.wrapping_add(1);
     update_cia_timers(mem, 1, false);
-    if let Some(r) = resid {
+    if let Some(r) = resid.as_mut() {
         r.clock_cycles(1);
     }
     *total_cyc += 1;
@@ -414,7 +413,8 @@ pub fn run_fast_batch(
                 for i in 0..c {
                     let bus_phase = phases[i as usize];
                     loop {
-                        let (_, ba_blocks_cpu) = tick_one_cycle(eng, mem, cpu, resid.as_deref_mut(), &mut total_cyc);
+                        let (_, ba_blocks_cpu) =
+                            tick_one_cycle(eng, mem, cpu, &mut resid, &mut total_cyc);
                         // Only stall on READ cycles — WRITE/INTERNAL proceed regardless.
                         if !(ba_blocks_cpu && bus_phase == BusPhase::Read) {
                             break;
@@ -425,14 +425,14 @@ pub fn run_fast_batch(
                 // dispatch cycles in the cycle count, matching Python's _handle_irq.
                 mem.recompute_pending_irq();
                 if irq_should_dispatch(cpu, mem.pending_irq) {
-                    dispatch_irq_hybrid(cpu, mem, eng, resid.as_deref_mut(), &mut total_cyc);
+                    dispatch_irq_hybrid(cpu, mem, eng, &mut resid, &mut total_cyc);
                 }
             } else {
-                coarse_cycles(cpu, mem, c, resid.as_deref_mut());
+                coarse_cycles(cpu, mem, c, &mut resid);
                 total_cyc += u64::from(c);
             }
         } else {
-            coarse_cycles(cpu, mem, c, resid.as_deref_mut());
+            coarse_cycles(cpu, mem, c, &mut resid);
             total_cyc += u64::from(c);
         }
         ins += 1;

--- a/rust/c64py-core/src/c64_fast.rs
+++ b/rust/c64py-core/src/c64_fast.rs
@@ -347,6 +347,7 @@ fn tick_one_cycle(
     total_cyc: &mut u64,
 ) -> (bool, bool) {
     let (irq_edge, ba_blocks_cpu) = eng.step(mem);
+    mem.per_cycle_capture_at_cursor();
     if irq_edge {
         mem.trigger_vic_irq(0x01);
     }

--- a/rust/c64py-core/src/c64_memory.rs
+++ b/rust/c64py-core/src/c64_memory.rs
@@ -1,5 +1,6 @@
 //! C64 memory decode (6510 banking + I/O). Mirrors [memory.py](memory.py) read/write fast path.
 
+use crate::per_cycle_composite::per_cycle_flat_index;
 use crate::resid_session::ResidSession;
 
 pub const ROM_BASIC_START: u16 = 0xA000;
@@ -105,6 +106,10 @@ pub struct C64MemoryMap<'a> {
     pub beam_cia2_ptr: *mut u8,
     pub beam_nlines: u16,
     pub beam_enabled: bool,
+    /// Optional per-cycle VIC grid (``8000 * 64`` + ``8000`` bytes) for pygame ``per-cycle`` tier.
+    pub per_cycle_vic_ptr: *mut u8,
+    pub per_cycle_cia2_ptr: *mut u8,
+    pub per_cycle_capture_enabled: bool,
 }
 
 impl<'a> C64MemoryMap<'a> {
@@ -144,6 +149,34 @@ impl<'a> C64MemoryMap<'a> {
             beam_cia2_ptr: std::ptr::null_mut(),
             beam_nlines: 0,
             beam_enabled: false,
+            per_cycle_vic_ptr: std::ptr::null_mut(),
+            per_cycle_cia2_ptr: std::ptr::null_mut(),
+            per_cycle_capture_enabled: false,
+        }
+    }
+
+    /// Copy VIC + CIA2 PA into per-cycle flat buffers when the cursor is inside the 320×200 window.
+    pub fn per_cycle_capture_at_cursor(&mut self) {
+        if !self.per_cycle_capture_enabled {
+            return;
+        }
+        if self.per_cycle_vic_ptr.is_null() || self.per_cycle_cia2_ptr.is_null() {
+            return;
+        }
+        let Some(idx) = per_cycle_flat_index(self.video_standard, self.raster_line, self.raster_cycles)
+        else {
+            return;
+        };
+        if idx >= crate::per_cycle_composite::PC_SAMPLES {
+            return;
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self.vic_regs.as_ptr(),
+                self.per_cycle_vic_ptr.add(idx * 64),
+                64,
+            );
+            *self.per_cycle_cia2_ptr.add(idx) = self.cia2_pra;
         }
     }
 

--- a/rust/c64py-core/src/lib.rs
+++ b/rust/c64py-core/src/lib.rs
@@ -5,8 +5,10 @@ mod c64_fast;
 mod c64_memory;
 mod c64_timing;
 mod c64_vicii;
+mod per_cycle_composite;
 mod resid_session;
 
+use crate::per_cycle_composite::composite_per_cycle_frame;
 use c64_cpu::CpuState;
 use c64_memory::{C64MemoryMap, CiaTimer};
 use c64_fast::run_fast_batch;
@@ -60,6 +62,8 @@ fn rust_core_version() -> &'static str {
     iec_enabled=false, iec_peer_clk_high=true, iec_peer_data_high=true,
     beam_render_enabled=false, beam_nlines=0u16,
     beam_vic_flat=None, beam_cia2_flat=None,
+    per_cycle_capture=false,
+    per_cycle_vic_flat=None, per_cycle_cia2_flat=None,
     trace_path=None,
 ))]
 fn run_fast_batch_py<'py>(
@@ -141,6 +145,9 @@ fn run_fast_batch_py<'py>(
     beam_nlines: u16,
     beam_vic_flat: Option<Bound<'py, PyByteArray>>,
     beam_cia2_flat: Option<Bound<'py, PyByteArray>>,
+    per_cycle_capture: bool,
+    per_cycle_vic_flat: Option<Bound<'py, PyByteArray>>,
+    per_cycle_cia2_flat: Option<Bound<'py, PyByteArray>>,
     trace_path: Option<String>,
 ) -> PyResult<Bound<'py, PyTuple>> {
     let vs = if video_standard.eq_ignore_ascii_case("ntsc") {
@@ -265,6 +272,44 @@ fn run_fast_batch_py<'py>(
         }
     }
 
+    let mut per_cycle_vic_ptr_usize: usize = 0;
+    let mut per_cycle_cia2_ptr_usize: usize = 0;
+    let mut per_cycle_capture_active = false;
+    if per_cycle_capture {
+        if !hybrid_effective {
+            return Err(PyValueError::new_err(
+                "per_cycle_capture requires hybrid VIC (accurate-rust with hybrid enabled)",
+            ));
+        }
+        let Some(ref pv) = per_cycle_vic_flat else {
+            return Err(PyValueError::new_err(
+                "per_cycle_vic_flat is required when per_cycle_capture is true",
+            ));
+        };
+        let Some(ref pc) = per_cycle_cia2_flat else {
+            return Err(PyValueError::new_err(
+                "per_cycle_cia2_flat is required when per_cycle_capture is true",
+            ));
+        };
+        unsafe {
+            let vs = pv.as_bytes_mut();
+            let cs = pc.as_bytes_mut();
+            const N: usize = 8000;
+            if vs.len() != N * 64 || cs.len() != N {
+                return Err(PyValueError::new_err(format!(
+                    "per_cycle buffers must be {} and {} bytes, got {} and {}",
+                    N * 64,
+                    N,
+                    vs.len(),
+                    cs.len()
+                )));
+            }
+            per_cycle_vic_ptr_usize = vs.as_mut_ptr() as usize;
+            per_cycle_cia2_ptr_usize = cs.as_mut_ptr() as usize;
+            per_cycle_capture_active = true;
+        }
+    }
+
     // Run the heavy batch outside the GIL so Python-side audio/UI threads can run.
     // Safe: we copied the bytearray into `backing` and do not touch Python objects inside.
     let result: Result<(OutTuple, Vec<u8>, Vec<u8>, [u32; 22]), String> =
@@ -321,6 +366,11 @@ fn run_fast_batch_py<'py>(
             mem.beam_nlines = beam_nlines;
             mem.beam_vic_ptr = beam_vic_ptr_usize as *mut u8;
             mem.beam_cia2_ptr = beam_cia2_ptr_usize as *mut u8;
+        }
+        if per_cycle_capture_active {
+            mem.per_cycle_capture_enabled = true;
+            mem.per_cycle_vic_ptr = per_cycle_vic_ptr_usize as *mut u8;
+            mem.per_cycle_cia2_ptr = per_cycle_cia2_ptr_usize as *mut u8;
         }
 
         let mut resid_box: Option<Box<ResidSession>> =
@@ -420,6 +470,9 @@ fn run_fast_batch_py<'py>(
         mem.beam_vic_ptr = std::ptr::null_mut();
         mem.beam_cia2_ptr = std::ptr::null_mut();
         mem.beam_enabled = false;
+        mem.per_cycle_vic_ptr = std::ptr::null_mut();
+        mem.per_cycle_cia2_ptr = std::ptr::null_mut();
+        mem.per_cycle_capture_enabled = false;
         Ok((out, backing, pcm_bytes, vpack))
     })());
     let (out, backing_out, pcm_bytes, vpack) = result.map_err(|e: String| PyValueError::new_err(e))?;
@@ -533,11 +586,101 @@ fn run_fast_batch_py<'py>(
     )
 }
 
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+#[pyo3(signature = (
+    ram, vic_flat, cia2_flat, char_rom, video_standard, palette_rgb48, rgb_out,
+    native_w, native_h, screen_left, screen_top, screen_w, screen_h, border_px,
+    skip_sprites=false, live_regb=None, live_cia2_pra=0x7F,
+))]
+fn composite_per_cycle_frame_py<'py>(
+    ram: Bound<'py, PyByteArray>,
+    vic_flat: Bound<'py, PyByteArray>,
+    cia2_flat: Bound<'py, PyByteArray>,
+    char_rom: Option<Bound<'py, PyBytes>>,
+    video_standard: String,
+    palette_rgb48: Bound<'py, PyBytes>,
+    rgb_out: Bound<'py, PyByteArray>,
+    native_w: usize,
+    native_h: usize,
+    screen_left: usize,
+    screen_top: usize,
+    screen_w: usize,
+    screen_h: usize,
+    border_px: usize,
+    skip_sprites: bool,
+    live_regb: Option<Bound<'py, PyBytes>>,
+    live_cia2_pra: u8,
+) -> PyResult<()> {
+    let vs = if video_standard.eq_ignore_ascii_case("ntsc") {
+        1u8
+    } else {
+        0u8
+    };
+    let ram_sl = unsafe { ram.as_bytes() };
+    let ram_arr: &[u8; 65536] = ram_sl
+        .try_into()
+        .map_err(|_| PyValueError::new_err("ram must be exactly 65536 bytes"))?;
+    let vf = unsafe { vic_flat.as_bytes() };
+    let cf = unsafe { cia2_flat.as_bytes() };
+    const N: usize = 8000;
+    if vf.len() != N * 64 || cf.len() != N {
+        return Err(PyValueError::new_err(format!(
+            "vic_flat/cia2_flat must be {} / {} bytes",
+            N * 64,
+            N
+        )));
+    }
+    let pal_sl = palette_rgb48.as_bytes();
+    let pal_arr: &[u8; 48] = pal_sl
+        .try_into()
+        .map_err(|_| PyValueError::new_err("palette_rgb48 must be exactly 48 bytes"))?;
+    let exp = native_w.saturating_mul(native_h).saturating_mul(3);
+    let rgb_buf = unsafe { rgb_out.as_bytes_mut() };
+    if rgb_buf.len() < exp {
+        return Err(PyValueError::new_err(format!(
+            "rgb_out too small: need {}, got {}",
+            exp,
+            rgb_buf.len()
+        )));
+    }
+    let mut live_b = [0u8; 64];
+    if let Some(b) = live_regb {
+        let s = b.as_bytes();
+        if s.len() >= 64 {
+            live_b.copy_from_slice(&s[..64]);
+        }
+    }
+    let cr = char_rom.as_ref().map(|b| b.as_bytes());
+    composite_per_cycle_frame(
+        ram_arr,
+        vf,
+        cf,
+        cr,
+        vs,
+        pal_arr,
+        &mut rgb_buf[..exp],
+        native_w,
+        native_h,
+        screen_left,
+        screen_top,
+        screen_w,
+        screen_h,
+        border_px,
+        skip_sprites,
+        &live_b,
+        live_cia2_pra,
+    )
+    .map_err(|e| PyValueError::new_err(e))?;
+    Ok(())
+}
+
 #[pymodule]
 fn c64py_rust_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ping, m)?)?;
     m.add_function(wrap_pyfunction!(rust_core_version, m)?)?;
     m.add_function(wrap_pyfunction!(run_fast_batch_py, m)?)?;
+    m.add_function(wrap_pyfunction!(composite_per_cycle_frame_py, m)?)?;
     Ok(())
 }
 

--- a/rust/c64py-core/src/per_cycle_composite.rs
+++ b/rust/c64py-core/src/per_cycle_composite.rs
@@ -210,6 +210,28 @@ fn plot_bitmap_scanline(
     }
 }
 
+/// Pixels that count as opaque "foreground" for VIC-II sprite/background priority ($D01B).
+#[inline]
+fn fg_opaque_hires_row(row_b: u8) -> [bool; 8] {
+    let mut o = [false; 8];
+    for dx in 0..8 {
+        o[dx] = (row_b >> (7 - dx)) & 1 != 0;
+    }
+    o
+}
+
+#[inline]
+fn fg_opaque_mcm_row(row_b: u8) -> [bool; 8] {
+    let mut o = [false; 8];
+    for pair in 0..4 {
+        let bits = (row_b >> (6 - pair * 2)) & 0x03;
+        let op = bits != 0;
+        o[pair * 2] = op;
+        o[pair * 2 + 1] = op;
+    }
+    o
+}
+
 fn overlay_sprites_column(
     buf: &mut [u8],
     w: usize,
@@ -224,6 +246,8 @@ fn overlay_sprites_column(
     screen_top: usize,
     screen_bottom: usize,
     pal48: &[u8],
+    sprite_bg_priority: u8,
+    fg_opaque: &[bool; 8],
 ) {
     let vic_bank = (3 - (pra & 0x03)) as u32 * 0x4000;
     let m = mode_from_regb(regb);
@@ -233,10 +257,12 @@ fn overlay_sprites_column(
     let mc1 = pal_rgb(pal48, regb[0x26]);
 
     let x0 = col * 8;
-    for sn in 0..8usize {
+    // VIC-II: lower sprite numbers are in front. Composite back-to-front (7 → 0).
+    for sn in (0..8usize).rev() {
         if regb[0x15] & (1 << sn) == 0 {
             continue;
         }
+        let behind_gfx = (sprite_bg_priority >> sn) & 1 != 0;
         let y_vic = regb[sn * 2 + 1];
         let row = y_win as i32 - y_vic as i32 + 50;
         if row < 0 || row >= 21 {
@@ -259,6 +285,10 @@ fn overlay_sprites_column(
 
         if multicolor {
             for dx in 0..8usize {
+                let dx_idx = dx;
+                if behind_gfx && fg_opaque[dx_idx] {
+                    continue;
+                }
                 let cx = x0 + dx;
                 let rel_x = cx as i32 - sprite_x;
                 if !(0..24).contains(&rel_x) {
@@ -286,6 +316,10 @@ fn overlay_sprites_column(
             }
         } else {
             for dx in 0..8usize {
+                let dx_idx = dx;
+                if behind_gfx && fg_opaque[dx_idx] {
+                    continue;
+                }
                 let cx = x0 + dx;
                 let rel_x = cx as i32 - sprite_x;
                 if !(0..24).contains(&rel_x) {
@@ -462,6 +496,12 @@ pub fn composite_per_cycle_frame(
                     pal48,
                 );
                 if !skip_sprites {
+                    let fg_op = if m.mcm {
+                        fg_opaque_mcm_row(byte)
+                    } else {
+                        fg_opaque_hires_row(byte)
+                    };
+                    let spr_pri = regb.get(0x1B).copied().unwrap_or(0);
                     overlay_sprites_column(
                         rgb_out,
                         native_w,
@@ -476,6 +516,8 @@ pub fn composite_per_cycle_frame(
                         screen_top,
                         screen_bottom,
                         pal48,
+                        spr_pri,
+                        &fg_op,
                     );
                 }
                 continue;
@@ -485,22 +527,25 @@ pub fn composite_per_cycle_frame(
             let raw_code = ram[(screen_base + char_index) & 0xFFFF];
             let color_code = ram[(COLOR_MEM + char_index) & 0xFFFF] & 0x0F;
 
+            let row_byte_text: u8;
             if m.ecm {
                 let bg_index = (raw_code >> 6) & 0x03;
                 let code_ecm = raw_code & 0x3F;
                 let char_bg = pal_rgb(pal48, bg_colors[bg_index as usize]);
                 fill_rect_rgb(rgb_out, native_w, x, py, 8, 1, char_bg);
                 let rows = read_glyph_rows(ram, char_rom, vic_bank, char_base, code_ecm);
+                row_byte_text = rows[scan];
                 plot_hires_scanline(
                     rgb_out,
                     native_w,
                     x,
                     py,
-                    rows[scan],
+                    row_byte_text,
                     pal_rgb(pal48, color_code),
                 );
             } else {
                 let rows = read_glyph_rows(ram, char_rom, vic_bank, char_base, raw_code);
+                row_byte_text = rows[scan];
                 let multicolor_text = m.mcm && !m.ecm;
                 if multicolor_text && (color_code & 0x08) != 0 {
                     plot_mcm_text_scanline(
@@ -508,7 +553,7 @@ pub fn composite_per_cycle_frame(
                         native_w,
                         x,
                         py,
-                        rows[scan],
+                        row_byte_text,
                         pal48,
                         color_code & 0x07,
                         bg_colors[0],
@@ -526,12 +571,21 @@ pub fn composite_per_cycle_frame(
                         native_w,
                         x,
                         py,
-                        rows[scan],
+                        row_byte_text,
                         pal_rgb(pal48, fg),
                     );
                 }
             }
             if !skip_sprites {
+                let multicolor_text = m.mcm && !m.ecm;
+                let fg_op = if m.ecm {
+                    fg_opaque_hires_row(row_byte_text)
+                } else if multicolor_text && (color_code & 0x08) != 0 {
+                    fg_opaque_mcm_row(row_byte_text)
+                } else {
+                    fg_opaque_hires_row(row_byte_text)
+                };
+                let spr_pri = regb.get(0x1B).copied().unwrap_or(0);
                 overlay_sprites_column(
                     rgb_out,
                     native_w,
@@ -546,6 +600,8 @@ pub fn composite_per_cycle_frame(
                     screen_top,
                     screen_bottom,
                     pal48,
+                    spr_pri,
+                    &fg_op,
                 );
             }
         }
@@ -564,5 +620,18 @@ mod tests {
         assert_eq!(per_cycle_flat_index(0, 250, 53), Some(7999));
         assert!(per_cycle_flat_index(0, 50, 14).is_none());
         assert!(per_cycle_flat_index(0, 51, 13).is_none());
+    }
+
+    #[test]
+    fn fg_opaque_hires_alternating() {
+        let o = fg_opaque_hires_row(0xAA);
+        assert_eq!(o, [true, false, true, false, true, false, true, false]);
+    }
+
+    #[test]
+    fn fg_opaque_mcm_pair() {
+        let o = fg_opaque_mcm_row(0xC0);
+        assert!(o[0] && o[1]);
+        assert!(!o[2] && !o[3]);
     }
 }

--- a/rust/c64py-core/src/per_cycle_composite.rs
+++ b/rust/c64py-core/src/per_cycle_composite.rs
@@ -257,6 +257,8 @@ fn overlay_sprites_column(
     let mc1 = pal_rgb(pal48, regb[0x26]);
 
     let x0 = col * 8;
+    let y_exp_mask = regb[0x17];
+    let x_exp_mask = regb[0x1D];
     // VIC-II: lower sprite numbers are in front. Composite back-to-front (7 → 0).
     for sn in (0..8usize).rev() {
         if regb[0x15] & (1 << sn) == 0 {
@@ -264,17 +266,27 @@ fn overlay_sprites_column(
         }
         let behind_gfx = (sprite_bg_priority >> sn) & 1 != 0;
         let y_vic = regb[sn * 2 + 1];
-        let row = y_win as i32 - y_vic as i32 + 50;
-        if row < 0 || row >= 21 {
-            continue;
-        }
-        let row = row as usize;
+        let row_disp = y_win as i32 - y_vic as i32 + 50;
+        let y_exp = (y_exp_mask >> sn) & 1 != 0;
+        let row = if y_exp {
+            if row_disp < 0 || row_disp >= 42 {
+                continue;
+            }
+            (row_disp / 2) as usize
+        } else {
+            if row_disp < 0 || row_disp >= 21 {
+                continue;
+            }
+            row_disp as usize
+        };
         let mut xv = regb[sn * 2] as u16;
         if (regb[0x10] & (1 << sn)) != 0 {
             xv |= 256;
         }
         let x_vic = xv;
         let sprite_x = x_vic as i32 - 24;
+        let x_exp = (x_exp_mask >> sn) & 1 != 0;
+        let max_rel: i32 = if x_exp { 48 } else { 24 };
         let multicolor = (regb[0x1C] & (1 << sn)) != 0;
         let sp = pal_rgb(pal48, regb[0x27 + sn]);
 
@@ -291,11 +303,11 @@ fn overlay_sprites_column(
                 }
                 let cx = x0 + dx;
                 let rel_x = cx as i32 - sprite_x;
-                if !(0..24).contains(&rel_x) {
+                if rel_x < 0 || rel_x >= max_rel {
                     continue;
                 }
-                let bp = rel_x / 2;
-                let bits = (row_data >> (22 - bp * 2)) & 0x03;
+                let bp = if x_exp { rel_x / 4 } else { rel_x / 2 };
+                let bits = (row_data >> ((22 - bp * 2) as u32)) & 0x03;
                 if bits == 0 {
                     continue;
                 }
@@ -322,10 +334,11 @@ fn overlay_sprites_column(
                 }
                 let cx = x0 + dx;
                 let rel_x = cx as i32 - sprite_x;
-                if !(0..24).contains(&rel_x) {
+                if rel_x < 0 || rel_x >= max_rel {
                     continue;
                 }
-                if (row_data >> (23 - rel_x)) & 1 == 0 {
+                let bi = if x_exp { rel_x / 2 } else { rel_x };
+                if (row_data >> ((23 - bi) as u32)) & 1 == 0 {
                     continue;
                 }
                 let px = screen_left + cx;

--- a/rust/c64py-core/src/per_cycle_composite.rs
+++ b/rust/c64py-core/src/per_cycle_composite.rs
@@ -1,0 +1,568 @@
+//! Host-side compositor: one pass over ``per_cycle_vic_flat`` + RAM → RGB888.
+//! Mirrors ``graphics.PygameInterface._render_frame_per_cycle`` (border, text/bitmap, sprites).
+
+const COLOR_MEM: usize = 0xD800;
+const VIC_D011_BMM: u8 = 0x20;
+const VIC_D011_ECM: u8 = 0x40;
+const VIC_D016_MCM: u8 = 0x10;
+
+const PC_FIRST_RASTER: u16 = 51;
+const PC_HEIGHT: u16 = 200;
+const PC_FIRST_CYCLE: u32 = 14;
+const PC_CYCLES: u32 = 40;
+pub const PC_SAMPLES: usize = (PC_HEIGHT as usize) * (PC_CYCLES as usize);
+
+#[inline]
+pub fn per_cycle_flat_index(_video_standard: u8, rl: u16, rc: u32) -> Option<usize> {
+    if rl < PC_FIRST_RASTER || rl >= PC_FIRST_RASTER + PC_HEIGHT {
+        return None;
+    }
+    if rc < PC_FIRST_CYCLE || rc >= PC_FIRST_CYCLE + PC_CYCLES {
+        return None;
+    }
+    let y = (rl - PC_FIRST_RASTER) as usize;
+    let x = (rc - PC_FIRST_CYCLE) as usize;
+    Some(y * (PC_CYCLES as usize) + x)
+}
+
+#[inline]
+fn pal_rgb(pal48: &[u8], idx: u8) -> [u8; 3] {
+    let i = (idx & 0x0F) as usize * 3;
+    [pal48[i], pal48[i + 1], pal48[i + 2]]
+}
+
+#[derive(Clone, Copy)]
+struct ModeBits {
+    bitmap: bool,
+    ecm: bool,
+    mcm: bool,
+    screen_base: u16,
+    bitmap_base: u16,
+    char_base: u16,
+}
+
+fn mode_from_regb(regb: &[u8]) -> ModeBits {
+    let d011 = *regb.get(0x11).unwrap_or(&0);
+    let d016 = *regb.get(0x16).unwrap_or(&0);
+    let d018 = *regb.get(0x18).unwrap_or(&0);
+    let bitmap = (d011 & VIC_D011_BMM) != 0;
+    let ecm = (d011 & VIC_D011_ECM) != 0;
+    let mcm = (d016 & VIC_D016_MCM) != 0;
+    let vm = (d018 >> 4) & 0x0F;
+    let cb = (d018 >> 1) & 0x07;
+    let screen_base = (vm as u16) * 0x0400;
+    let (bitmap_base, char_base) = if bitmap {
+        let bb = if (d018 & 0x08) != 0 { 0x2000u16 } else { 0x0000u16 };
+        (bb, 0u16)
+    } else {
+        (0u16, (cb as u16) * 0x0800)
+    };
+    ModeBits {
+        bitmap,
+        ecm,
+        mcm,
+        screen_base,
+        bitmap_base,
+        char_base,
+    }
+}
+
+#[inline]
+fn vic_fetches_charset_rom(vic_bank: u32, rel_within_bank: u32) -> bool {
+    let rel = rel_within_bank & 0x3FFF;
+    if rel < 0x1000 || rel >= 0x2000 {
+        return false;
+    }
+    vic_bank == 0x0000 || vic_bank == 0x8000
+}
+
+fn read_glyph_rows(
+    ram: &[u8],
+    char_rom: Option<&[u8]>,
+    vic_bank: u32,
+    char_base: u16,
+    code: u8,
+) -> [u8; 8] {
+    let mut rows = [0u8; 8];
+    for r in 0..8usize {
+        let rel = (char_base as u32).wrapping_add((code as u32) * 8 + r as u32) & 0x3FFF;
+        rows[r] = if let Some(cr) = char_rom {
+            if vic_fetches_charset_rom(vic_bank, rel) {
+                cr.get(rel as usize - 0x1000).copied().unwrap_or(0)
+            } else {
+                ram[((vic_bank + rel) & 0xFFFF) as usize]
+            }
+        } else {
+            ram[((vic_bank + rel) & 0xFFFF) as usize]
+        };
+    }
+    rows
+}
+
+fn plot_hires_scanline(buf: &mut [u8], w: usize, x: usize, y: usize, row_b: u8, fg: [u8; 3]) {
+    if y >= buf.len() / (w * 3) {
+        return;
+    }
+    let base = y * w * 3;
+    for xx in 0..8usize {
+        if row_b & (1 << (7 - xx)) == 0 {
+            continue;
+        }
+        let px = x + xx;
+        if px >= w {
+            continue;
+        }
+        let i = base + px * 3;
+        buf[i] = fg[0];
+        buf[i + 1] = fg[1];
+        buf[i + 2] = fg[2];
+    }
+}
+
+fn fill_rect_rgb(buf: &mut [u8], w: usize, x0: usize, y0: usize, rw: usize, rh: usize, c: [u8; 3]) {
+    let h = buf.len() / (w * 3);
+    let x1 = (x0 + rw).min(w);
+    let y1 = (y0 + rh).min(h);
+    if x0 >= x1 || y0 >= y1 {
+        return;
+    }
+    for yy in y0..y1 {
+        let row = yy * w * 3;
+        for xx in x0..x1 {
+            let i = row + xx * 3;
+            buf[i] = c[0];
+            buf[i + 1] = c[1];
+            buf[i + 2] = c[2];
+        }
+    }
+}
+
+fn plot_mcm_text_scanline(buf: &mut [u8], w: usize, x: usize, y: usize, row_b: u8, pal48: &[u8], cc: u8, bg: u8, c1: u8, c2: u8) {
+    let p0 = pal_rgb(pal48, bg);
+    let p1 = pal_rgb(pal48, c1);
+    let p2 = pal_rgb(pal48, c2);
+    let p3 = pal_rgb(pal48, cc);
+    for pair in 0..4usize {
+        let bits = (row_b >> (6 - pair * 2)) & 0x03;
+        let c = if bits == 0 {
+            p0
+        } else if bits == 1 {
+            p1
+        } else if bits == 2 {
+            p2
+        } else {
+            p3
+        };
+        let px = x + pair * 2;
+        fill_rect_rgb(buf, w, px, y, 2, 1, c);
+    }
+}
+
+fn plot_bitmap_scanline(
+    buf: &mut [u8],
+    w: usize,
+    base_x: usize,
+    yy: usize,
+    byte: u8,
+    multicolor: bool,
+    bg0: u8,
+    color_data: u8,
+    color_mem: u8,
+    pal48: &[u8],
+) {
+    if multicolor {
+        let c1 = (color_data >> 4) & 0x0F;
+        let c2 = color_data & 0x0F;
+        let c3 = color_mem & 0x0F;
+        for bit_pair in 0..4usize {
+            let pixel_bits = (byte >> (6 - bit_pair * 2)) & 0x03;
+            let c = if pixel_bits == 0 {
+                pal_rgb(pal48, bg0)
+            } else if pixel_bits == 1 {
+                pal_rgb(pal48, c1)
+            } else if pixel_bits == 2 {
+                pal_rgb(pal48, c2)
+            } else {
+                pal_rgb(pal48, c3)
+            };
+            fill_rect_rgb(buf, w, base_x + bit_pair * 2, yy, 2, 1, c);
+        }
+    } else {
+        let c1 = (color_data >> 4) & 0x0F;
+        let c0 = color_data & 0x0F;
+        let p0 = pal_rgb(pal48, c0);
+        let p1 = pal_rgb(pal48, c1);
+        if yy >= buf.len() / (w * 3) {
+            return;
+        }
+        let base_row = yy * w * 3;
+        for bit in 0..8usize {
+            let px = base_x + bit;
+            if px >= w {
+                continue;
+            }
+            let c = if (byte >> (7 - bit)) & 1 != 0 { p1 } else { p0 };
+            let i = base_row + px * 3;
+            buf[i] = c[0];
+            buf[i + 1] = c[1];
+            buf[i + 2] = c[2];
+        }
+    }
+}
+
+fn overlay_sprites_column(
+    buf: &mut [u8],
+    w: usize,
+    ram: &[u8],
+    regb: &[u8; 64],
+    pra: u8,
+    y_win: usize,
+    col: usize,
+    py: usize,
+    screen_left: usize,
+    screen_right: usize,
+    screen_top: usize,
+    screen_bottom: usize,
+    pal48: &[u8],
+) {
+    let vic_bank = (3 - (pra & 0x03)) as u32 * 0x4000;
+    let m = mode_from_regb(regb);
+    let matrix = (vic_bank + m.screen_base as u32) as usize & 0xFFFF;
+
+    let mc0 = pal_rgb(pal48, regb[0x25]);
+    let mc1 = pal_rgb(pal48, regb[0x26]);
+
+    let x0 = col * 8;
+    for sn in 0..8usize {
+        if regb[0x15] & (1 << sn) == 0 {
+            continue;
+        }
+        let y_vic = regb[sn * 2 + 1];
+        let row = y_win as i32 - y_vic as i32 + 50;
+        if row < 0 || row >= 21 {
+            continue;
+        }
+        let row = row as usize;
+        let mut xv = regb[sn * 2] as u16;
+        if (regb[0x10] & (1 << sn)) != 0 {
+            xv |= 256;
+        }
+        let x_vic = xv;
+        let sprite_x = x_vic as i32 - 24;
+        let multicolor = (regb[0x1C] & (1 << sn)) != 0;
+        let sp = pal_rgb(pal48, regb[0x27 + sn]);
+
+        let ptr = ram[(matrix + 0x3F8 + sn) & 0xFFFF] as usize;
+        let sprite_addr = (vic_bank as usize + ((ptr & 0xFF) << 6)) & 0xFFFF;
+        let bo = (sprite_addr + row * 3) & 0xFFFF;
+        let row_data = (u32::from(ram[bo]) << 16) | (u32::from(ram[(bo + 1) & 0xFFFF]) << 8) | u32::from(ram[(bo + 2) & 0xFFFF]);
+
+        if multicolor {
+            for dx in 0..8usize {
+                let cx = x0 + dx;
+                let rel_x = cx as i32 - sprite_x;
+                if !(0..24).contains(&rel_x) {
+                    continue;
+                }
+                let bp = rel_x / 2;
+                let bits = (row_data >> (22 - bp * 2)) & 0x03;
+                if bits == 0 {
+                    continue;
+                }
+                let (r, g, b) = if bits == 1 {
+                    (mc0[0], mc0[1], mc0[2])
+                } else if bits == 2 {
+                    (sp[0], sp[1], sp[2])
+                } else {
+                    (mc1[0], mc1[1], mc1[2])
+                };
+                let px = screen_left + cx;
+                if px >= screen_left && px < screen_right && py >= screen_top && py < screen_bottom {
+                    let i = py * w * 3 + px * 3;
+                    buf[i] = r;
+                    buf[i + 1] = g;
+                    buf[i + 2] = b;
+                }
+            }
+        } else {
+            for dx in 0..8usize {
+                let cx = x0 + dx;
+                let rel_x = cx as i32 - sprite_x;
+                if !(0..24).contains(&rel_x) {
+                    continue;
+                }
+                if (row_data >> (23 - rel_x)) & 1 == 0 {
+                    continue;
+                }
+                let px = screen_left + cx;
+                if px >= screen_left && px < screen_right && py >= screen_top && py < screen_bottom {
+                    let i = py * w * 3 + px * 3;
+                    buf[i] = sp[0];
+                    buf[i + 1] = sp[1];
+                    buf[i + 2] = sp[2];
+                }
+            }
+        }
+    }
+}
+
+/// Composite one frame into *rgb_out* (row-major RGB888). ``vic_flat`` length must be ``PC_SAMPLES * 64``.
+pub fn composite_per_cycle_frame(
+    ram: &[u8; 65536],
+    vic_flat: &[u8],
+    cia_flat: &[u8],
+    char_rom: Option<&[u8]>,
+    video_standard: u8,
+    pal48: &[u8; 48],
+    rgb_out: &mut [u8],
+    native_w: usize,
+    native_h: usize,
+    screen_left: usize,
+    screen_top: usize,
+    screen_w: usize,
+    screen_h: usize,
+    border_px: usize,
+    skip_sprites: bool,
+    live_regb: &[u8; 64],
+    live_cia2_pra: u8,
+) -> Result<(), &'static str> {
+    if vic_flat.len() != PC_SAMPLES * 64 || cia_flat.len() != PC_SAMPLES {
+        return Err("per_cycle flat wrong size");
+    }
+    let exp = native_w.saturating_mul(native_h).saturating_mul(3);
+    if rgb_out.len() < exp {
+        return Err("rgb_out too small");
+    }
+    let screen_right = screen_left + screen_w;
+    let screen_bottom = screen_top + screen_h;
+
+    let nlines = if video_standard == 1 { 263u16 } else { 312u16 };
+    let content_first = PC_FIRST_RASTER;
+    let content_h = PC_HEIGHT as usize;
+    let top_lines = (content_first as usize).min(nlines as usize);
+    let bottom_lines = nlines as usize - (content_first as usize + content_h);
+
+    let flat_mv = vic_flat;
+    let cia_mv = cia_flat;
+
+    for y in 0..native_h {
+        let rl = if border_px > 0 && y < border_px {
+            if top_lines > 0 {
+                (y * top_lines / border_px) as u16
+            } else {
+                0
+            }
+        } else if y < border_px + content_h {
+            content_first + (y - border_px) as u16
+        } else {
+            let yy = y - (border_px + content_h);
+            if border_px > 0 && bottom_lines > 0 {
+                (content_first + content_h as u16) + (yy * bottom_lines / border_px) as u16
+            } else {
+                content_first + content_h as u16
+            }
+        };
+        let rl = (rl as usize % nlines as usize) as u16;
+
+        let y_win = rl as i32 - PC_FIRST_RASTER as i32;
+        let regb: [u8; 64] = if y_win >= 0 && (y_win as usize) < content_h {
+            let o = (y_win as usize) * (PC_CYCLES as usize) * 64;
+            if o + 64 <= flat_mv.len() {
+                flat_mv[o..o + 64].try_into().unwrap()
+            } else {
+                *live_regb
+            }
+        } else {
+            *live_regb
+        };
+
+        let mut border_code = regb[0x20] & 0x0F;
+        if border_code == 0 && regb.iter().all(|&b| b == 0) {
+            border_code = 0x0E;
+        }
+        let c = pal_rgb(pal48, border_code);
+        if y < screen_top || y >= screen_top + screen_h {
+            fill_rect_rgb(rgb_out, native_w, 0, y, native_w, 1, c);
+        } else {
+            if screen_left > 0 {
+                fill_rect_rgb(rgb_out, native_w, 0, y, screen_left, 1, c);
+            }
+            if screen_right < native_w {
+                fill_rect_rgb(rgb_out, native_w, screen_right, y, native_w - screen_right, 1, c);
+            }
+        }
+    }
+
+    let content_px_w = (PC_CYCLES as usize) * 8;
+    for y_win in 0..content_h {
+        let o_bg = y_win * (PC_CYCLES as usize) * 64;
+        let regb_bg: [u8; 64] = if o_bg + 64 <= flat_mv.len() {
+            flat_mv[o_bg..o_bg + 64].try_into().unwrap()
+        } else {
+            *live_regb
+        };
+        let use_live = regb_bg.iter().all(|&b| b == 0);
+        let regb_bg_ref = if use_live { live_regb } else { &regb_bg };
+        let bg_scan = pal_rgb(pal48, regb_bg_ref[0x21]);
+        let py = screen_top + y_win;
+        fill_rect_rgb(
+            rgb_out,
+            native_w,
+            screen_left,
+            py,
+            content_px_w,
+            1,
+            bg_scan,
+        );
+
+        let text_row = y_win / 8;
+        let scan = y_win % 8;
+        for col in 0..(PC_CYCLES as usize) {
+            let idx = y_win * (PC_CYCLES as usize) + col;
+            let o = idx * 64;
+            let mut regb: [u8; 64] = if o + 64 <= flat_mv.len() {
+                flat_mv[o..o + 64].try_into().unwrap()
+            } else {
+                *live_regb
+            };
+            let mut pra = cia_mv.get(idx).copied().unwrap_or(live_cia2_pra);
+            if regb.iter().all(|&b| b == 0) {
+                regb = *live_regb;
+                pra = live_cia2_pra;
+            }
+            let m = mode_from_regb(&regb);
+            let vic_bank = (3 - (pra & 0x03)) as u32 * 0x4000;
+            let bg0 = regb[0x21] & 0x0F;
+            let bg_colors = [
+                regb[0x21] & 0x0F,
+                regb[0x22] & 0x0F,
+                regb[0x23] & 0x0F,
+                regb[0x24] & 0x0F,
+            ];
+            let screen_base = (vic_bank + m.screen_base as u32) as usize & 0xFFFF;
+            let bitmap_base = (vic_bank + m.bitmap_base as u32) as usize & 0xFFFF;
+            let x = screen_left + col * 8;
+            let char_index = text_row * 40 + col;
+
+            if m.bitmap {
+                let color_data = ram[(screen_base + char_index) & 0xFFFF];
+                let color_mem = ram[(COLOR_MEM + char_index) & 0xFFFF] & 0x0F;
+                let bitmap_offset = char_index * 8;
+                let byte = ram[(bitmap_base + bitmap_offset + scan) & 0xFFFF];
+                plot_bitmap_scanline(
+                    rgb_out,
+                    native_w,
+                    x,
+                    py,
+                    byte,
+                    m.mcm,
+                    bg0,
+                    color_data,
+                    color_mem,
+                    pal48,
+                );
+                if !skip_sprites {
+                    overlay_sprites_column(
+                        rgb_out,
+                        native_w,
+                        ram,
+                        &regb,
+                        pra,
+                        y_win,
+                        col,
+                        py,
+                        screen_left,
+                        screen_right,
+                        screen_top,
+                        screen_bottom,
+                        pal48,
+                    );
+                }
+                continue;
+            }
+
+            let char_base = m.char_base;
+            let raw_code = ram[(screen_base + char_index) & 0xFFFF];
+            let color_code = ram[(COLOR_MEM + char_index) & 0xFFFF] & 0x0F;
+
+            if m.ecm {
+                let bg_index = (raw_code >> 6) & 0x03;
+                let code_ecm = raw_code & 0x3F;
+                let char_bg = pal_rgb(pal48, bg_colors[bg_index as usize]);
+                fill_rect_rgb(rgb_out, native_w, x, py, 8, 1, char_bg);
+                let rows = read_glyph_rows(ram, char_rom, vic_bank, char_base, code_ecm);
+                plot_hires_scanline(
+                    rgb_out,
+                    native_w,
+                    x,
+                    py,
+                    rows[scan],
+                    pal_rgb(pal48, color_code),
+                );
+            } else {
+                let rows = read_glyph_rows(ram, char_rom, vic_bank, char_base, raw_code);
+                let multicolor_text = m.mcm && !m.ecm;
+                if multicolor_text && (color_code & 0x08) != 0 {
+                    plot_mcm_text_scanline(
+                        rgb_out,
+                        native_w,
+                        x,
+                        py,
+                        rows[scan],
+                        pal48,
+                        color_code & 0x07,
+                        bg_colors[0],
+                        bg_colors[1],
+                        bg_colors[2],
+                    );
+                } else {
+                    let fg = if multicolor_text {
+                        color_code & 0x07
+                    } else {
+                        color_code
+                    };
+                    plot_hires_scanline(
+                        rgb_out,
+                        native_w,
+                        x,
+                        py,
+                        rows[scan],
+                        pal_rgb(pal48, fg),
+                    );
+                }
+            }
+            if !skip_sprites {
+                overlay_sprites_column(
+                    rgb_out,
+                    native_w,
+                    ram,
+                    &regb,
+                    pra,
+                    y_win,
+                    col,
+                    py,
+                    screen_left,
+                    screen_right,
+                    screen_top,
+                    screen_bottom,
+                    pal48,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idx_corners() {
+        assert_eq!(per_cycle_flat_index(0, 51, 14), Some(0));
+        assert_eq!(per_cycle_flat_index(0, 51, 53), Some(39));
+        assert_eq!(per_cycle_flat_index(0, 250, 53), Some(7999));
+        assert!(per_cycle_flat_index(0, 50, 14).is_none());
+        assert!(per_cycle_flat_index(0, 51, 13).is_none());
+    }
+}

--- a/rust/c64py-core/src/per_cycle_composite.rs
+++ b/rust/c64py-core/src/per_cycle_composite.rs
@@ -232,11 +232,25 @@ fn fg_opaque_mcm_row(row_b: u8) -> [bool; 8] {
     o
 }
 
+/// Bytes taken from the **first visible cycle** of the raster line (``regb_line``) so IRQs that
+/// rewrite sprite graphics between character cycles do not splice a different expansion /
+/// multicolor / palette into the middle of one on-screen sprite. X, enable, and mode bits still
+/// come from the per-column ``regb`` sample.
+#[inline]
+fn sprite_latched_byte(regb: &[u8; 64], regb_line: &[u8; 64], i: usize) -> u8 {
+    match i {
+        0x17 | 0x1D | 0x1C | 0x1B => regb_line[i],
+        0x25..=0x2E => regb_line[i],
+        _ => regb[i],
+    }
+}
+
 fn overlay_sprites_column(
     buf: &mut [u8],
     w: usize,
     ram: &[u8],
     regb: &[u8; 64],
+    regb_line: &[u8; 64],
     pra: u8,
     y_win: usize,
     col: usize,
@@ -246,19 +260,19 @@ fn overlay_sprites_column(
     screen_top: usize,
     screen_bottom: usize,
     pal48: &[u8],
-    sprite_bg_priority: u8,
     fg_opaque: &[bool; 8],
 ) {
     let vic_bank = (3 - (pra & 0x03)) as u32 * 0x4000;
     let m = mode_from_regb(regb);
     let matrix = (vic_bank + m.screen_base as u32) as usize & 0xFFFF;
 
-    let mc0 = pal_rgb(pal48, regb[0x25]);
-    let mc1 = pal_rgb(pal48, regb[0x26]);
+    let mc0 = pal_rgb(pal48, sprite_latched_byte(regb, regb_line, 0x25));
+    let mc1 = pal_rgb(pal48, sprite_latched_byte(regb, regb_line, 0x26));
 
     let x0 = col * 8;
-    let y_exp_mask = regb[0x17];
-    let x_exp_mask = regb[0x1D];
+    let y_exp_mask = sprite_latched_byte(regb, regb_line, 0x17);
+    let x_exp_mask = sprite_latched_byte(regb, regb_line, 0x1D);
+    let sprite_bg_priority = sprite_latched_byte(regb, regb_line, 0x1B);
     // VIC-II: lower sprite numbers are in front. Composite back-to-front (7 → 0).
     for sn in (0..8usize).rev() {
         if regb[0x15] & (1 << sn) == 0 {
@@ -287,8 +301,8 @@ fn overlay_sprites_column(
         let sprite_x = x_vic as i32 - 24;
         let x_exp = (x_exp_mask >> sn) & 1 != 0;
         let max_rel: i32 = if x_exp { 48 } else { 24 };
-        let multicolor = (regb[0x1C] & (1 << sn)) != 0;
-        let sp = pal_rgb(pal48, regb[0x27 + sn]);
+        let multicolor = (sprite_latched_byte(regb, regb_line, 0x1C) & (1 << sn)) != 0;
+        let sp = pal_rgb(pal48, sprite_latched_byte(regb, regb_line, 0x27 + sn));
 
         let ptr = ram[(matrix + 0x3F8 + sn) & 0xFFFF] as usize;
         let sprite_addr = (vic_bank as usize + ((ptr & 0xFF) << 6)) & 0xFFFF;
@@ -462,6 +476,17 @@ pub fn composite_per_cycle_frame(
             bg_scan,
         );
 
+        let regb_line_owned: [u8; 64] = if o_bg + 64 <= flat_mv.len() {
+            flat_mv[o_bg..o_bg + 64].try_into().unwrap()
+        } else {
+            *live_regb
+        };
+        let regb_line: &[u8; 64] = if regb_line_owned.iter().all(|&b| b == 0) {
+            live_regb
+        } else {
+            &regb_line_owned
+        };
+
         let text_row = y_win / 8;
         let scan = y_win % 8;
         for col in 0..(PC_CYCLES as usize) {
@@ -514,12 +539,12 @@ pub fn composite_per_cycle_frame(
                     } else {
                         fg_opaque_hires_row(byte)
                     };
-                    let spr_pri = regb.get(0x1B).copied().unwrap_or(0);
                     overlay_sprites_column(
                         rgb_out,
                         native_w,
                         ram,
                         &regb,
+                        regb_line,
                         pra,
                         y_win,
                         col,
@@ -529,7 +554,6 @@ pub fn composite_per_cycle_frame(
                         screen_top,
                         screen_bottom,
                         pal48,
-                        spr_pri,
                         &fg_op,
                     );
                 }
@@ -598,12 +622,12 @@ pub fn composite_per_cycle_frame(
                 } else {
                     fg_opaque_hires_row(row_byte_text)
                 };
-                let spr_pri = regb.get(0x1B).copied().unwrap_or(0);
                 overlay_sprites_column(
                     rgb_out,
                     native_w,
                     ram,
                     &regb,
+                    regb_line,
                     pra,
                     y_win,
                     col,
@@ -613,7 +637,6 @@ pub fn composite_per_cycle_frame(
                     screen_top,
                     screen_bottom,
                     pal48,
-                    spr_pri,
                     &fg_op,
                 );
             }

--- a/scripts/render_n_frames.py
+++ b/scripts/render_n_frames.py
@@ -75,6 +75,12 @@ def main() -> int:
     ap.add_argument("--stride", type=int, default=1, help="Save every K-th frame")
     ap.add_argument("--out-dir", required=True, help="Directory to write frame_NNN.png into")
     ap.add_argument(
+        "--video-rendering",
+        choices=("per-raster", "per-cycle"),
+        default="per-raster",
+        help="Host sampling tier for PygameInterface._render_frame (default: per-raster beam)",
+    )
+    ap.add_argument(
         "--warmup-cycles",
         type=int,
         default=PAL_CYCLES_PER_FRAME,
@@ -85,12 +91,21 @@ def main() -> int:
     os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
     os.makedirs(args.out_dir, exist_ok=True)
 
-    emu = _C64(vic_emulation="accurate-rust")
+    emu = _C64(
+        vic_emulation="accurate-python" if args.video_rendering == "per-cycle" else "accurate-rust"
+    )
     _load_snapshot(emu, args.snapshot)
 
-    emu.memory.beam_render_enabled = True
-    emu.memory.ensure_beam_buffers()
-    emu.memory.prime_beam_snapshots_from_current_vic()
+    if args.video_rendering == "per-cycle":
+        emu.memory.beam_render_enabled = False
+        emu.memory.per_cycle_render_enabled = True
+        emu.memory.ensure_per_cycle_buffers()
+        emu.memory.prime_per_cycle_snapshots_from_current_vic()
+    else:
+        emu.memory.beam_render_enabled = True
+        emu.memory.per_cycle_render_enabled = False
+        emu.memory.ensure_beam_buffers()
+        emu.memory.prime_beam_snapshots_from_current_vic()
 
     _step_cycles(emu, args.warmup_cycles)
 
@@ -117,7 +132,7 @@ def main() -> int:
         _step_cycles(emu, PAL_CYCLES_PER_FRAME)
         if frame_idx % args.stride != 0:
             continue
-        ui._render_frame_beam()
+        ui._render_frame()
         buf = bytes(ui._rgb_frame.buf)
         digest = hashlib.sha256(buf).hexdigest()
         hashes.append((frame_idx, digest))

--- a/test/test_disk_tier_cli.py
+++ b/test/test_disk_tier_cli.py
@@ -56,10 +56,13 @@ def _apply_video_aliases_and_accurate(ns):
     if ns.video_rendering in aliases:
         ns.video_rendering = aliases[ns.video_rendering]
     if ns.accurate:
-        ns.video_rendering = "per-raster"
-        ns.vic_emulation = "accurate-rust"
-    if ns.video_rendering == "per-cycle":
-        ns.video_rendering = "per-raster"
+        if ns.video_rendering != "per-cycle":
+            ns.video_rendering = "per-raster"
+            ns.vic_emulation = "accurate-rust"
+        else:
+            ns.vic_emulation = "accurate-python"
+    if ns.video_rendering == "per-cycle" and ns.vic_emulation != "accurate-python":
+        ns.vic_emulation = "accurate-python"
 
 
 def test_default_video_vic():
@@ -82,6 +85,22 @@ def test_accurate_overrides_config_style_defaults():
     _apply_video_aliases_and_accurate(ns)
     assert ns.vic_emulation == "accurate-rust"
     assert ns.video_rendering == "per-raster"
+
+
+def test_per_cycle_keeps_rendering_tier_and_forces_python_vic():
+    ns = _build_parser().parse_args(
+        ["--video-rendering", "per-cycle", "--vic-emulation", "accurate-rust"]
+    )
+    _apply_video_aliases_and_accurate(ns)
+    assert ns.video_rendering == "per-cycle"
+    assert ns.vic_emulation == "accurate-python"
+
+
+def test_accurate_with_per_cycle_uses_python_vic():
+    ns = _build_parser().parse_args(["--accurate", "--video-rendering", "per-cycle"])
+    _apply_video_aliases_and_accurate(ns)
+    assert ns.video_rendering == "per-cycle"
+    assert ns.vic_emulation == "accurate-python"
 
 
 @pytest.mark.parametrize("mode", ["resid", "python-sid", "disabled"])

--- a/test/test_disk_tier_cli.py
+++ b/test/test_disk_tier_cli.py
@@ -50,8 +50,11 @@ def _build_parser():
     return ap
 
 
-def _apply_video_aliases_and_accurate(ns):
-    """Mirror post-parse logic in ``C64.py`` (aliases + ``--accurate`` + per-cycle)."""
+def _apply_video_aliases_and_accurate(ns, *, rust_per_cycle_ok: bool = True):
+    """Mirror post-parse logic in ``C64.py`` (aliases + ``--accurate`` + per-cycle).
+
+    *rust_per_cycle_ok* mirrors ``_core.is_available`` and ``C64PY_RUST_PER_CYCLE``.
+    """
     aliases = {"fast": "per-frame", "accurate": "per-raster"}
     if ns.video_rendering in aliases:
         ns.video_rendering = aliases[ns.video_rendering]
@@ -60,9 +63,15 @@ def _apply_video_aliases_and_accurate(ns):
             ns.video_rendering = "per-raster"
             ns.vic_emulation = "accurate-rust"
         else:
+            if rust_per_cycle_ok:
+                ns.vic_emulation = "accurate-rust"
+            else:
+                ns.vic_emulation = "accurate-python"
+    if ns.video_rendering == "per-cycle":
+        if rust_per_cycle_ok and ns.vic_emulation != "accurate-python":
+            ns.vic_emulation = "accurate-rust"
+        elif not rust_per_cycle_ok and ns.vic_emulation != "accurate-python":
             ns.vic_emulation = "accurate-python"
-    if ns.video_rendering == "per-cycle" and ns.vic_emulation != "accurate-python":
-        ns.vic_emulation = "accurate-python"
 
 
 def test_default_video_vic():
@@ -87,18 +96,42 @@ def test_accurate_overrides_config_style_defaults():
     assert ns.video_rendering == "per-raster"
 
 
-def test_per_cycle_keeps_rendering_tier_and_forces_python_vic():
+def test_per_cycle_keeps_rendering_tier_and_rust_vic_when_extension_available():
     ns = _build_parser().parse_args(
         ["--video-rendering", "per-cycle", "--vic-emulation", "accurate-rust"]
     )
-    _apply_video_aliases_and_accurate(ns)
+    _apply_video_aliases_and_accurate(ns, rust_per_cycle_ok=True)
+    assert ns.video_rendering == "per-cycle"
+    assert ns.vic_emulation == "accurate-rust"
+
+
+def test_per_cycle_respects_explicit_accurate_python_even_with_rust():
+    ns = _build_parser().parse_args(
+        ["--video-rendering", "per-cycle", "--vic-emulation", "accurate-python"]
+    )
+    _apply_video_aliases_and_accurate(ns, rust_per_cycle_ok=True)
+    assert ns.vic_emulation == "accurate-python"
+
+
+def test_accurate_with_per_cycle_uses_rust_vic_when_extension_available():
+    ns = _build_parser().parse_args(["--accurate", "--video-rendering", "per-cycle"])
+    _apply_video_aliases_and_accurate(ns, rust_per_cycle_ok=True)
+    assert ns.video_rendering == "per-cycle"
+    assert ns.vic_emulation == "accurate-rust"
+
+
+def test_per_cycle_forces_python_vic_without_rust_extension():
+    ns = _build_parser().parse_args(
+        ["--video-rendering", "per-cycle", "--vic-emulation", "accurate-rust"]
+    )
+    _apply_video_aliases_and_accurate(ns, rust_per_cycle_ok=False)
     assert ns.video_rendering == "per-cycle"
     assert ns.vic_emulation == "accurate-python"
 
 
-def test_accurate_with_per_cycle_uses_python_vic():
+def test_accurate_with_per_cycle_uses_python_vic_without_rust_extension():
     ns = _build_parser().parse_args(["--accurate", "--video-rendering", "per-cycle"])
-    _apply_video_aliases_and_accurate(ns)
+    _apply_video_aliases_and_accurate(ns, rust_per_cycle_ok=False)
     assert ns.video_rendering == "per-cycle"
     assert ns.vic_emulation == "accurate-python"
 

--- a/test/test_per_cycle_rust_composite.py
+++ b/test/test_per_cycle_rust_composite.py
@@ -1,0 +1,38 @@
+"""Smoke test for optional Rust per-cycle compositor (``composite_per_cycle_frame``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from c64py import _core
+from c64py.memory import MemoryMap
+
+pytestmark = pytest.mark.skipif(
+    not _core.is_available,
+    reason="c64py_rust_core not built / importable",
+)
+
+
+def test_composite_per_cycle_frame_smoke() -> None:
+    mem = MemoryMap(video_standard="pal")
+    mem.per_cycle_render_enabled = True
+    mem.ensure_per_cycle_buffers()
+    mem.prime_per_cycle_snapshots_from_current_vic()
+    pal48 = bytes(48)
+    nw, nh = 40, 30
+    out = bytearray(nw * nh * 3)
+    _core.composite_per_cycle_frame(
+        mem,
+        pal48,
+        out,
+        video_standard="pal",
+        native_width=nw,
+        native_height=nh,
+        screen_left=0,
+        screen_top=0,
+        screen_width=nw,
+        screen_height=nh,
+        border_px=0,
+        skip_sprites=True,
+    )
+    assert len(out) == nw * nh * 3

--- a/test/test_per_cycle_vic_buffers.py
+++ b/test/test_per_cycle_vic_buffers.py
@@ -72,3 +72,21 @@ def test_prime_per_cycle_snapshots_is_gated() -> None:
 
     assert mem.per_cycle_vic_flat is None
     assert mem.per_cycle_snapshots_primed is False
+
+
+def test_vic_fg_opaque_helpers_match_compositor_rules() -> None:
+    from c64py.graphics import PygameInterface
+
+    assert PygameInterface._vic_fg_opaque_hires_row(0xAA) == (
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    )
+    t = PygameInterface._vic_fg_opaque_mcm_row(0xC0)
+    assert t[0] and t[1]
+    assert not t[2] and not t[3]

--- a/test/test_per_cycle_vic_buffers.py
+++ b/test/test_per_cycle_vic_buffers.py
@@ -1,50 +1,36 @@
-"""Per-cycle VIC buffer geometry and allocation foundation."""
-
 from c64py.memory import MemoryMap
 from c64py.video_beam import per_cycle_geometry
 
 
 def test_per_cycle_geometry_pal_visible_window() -> None:
     geom = per_cycle_geometry("pal")
-
-    assert geom.raster_lines == 312
-    assert geom.cycles_per_line == 63
-    assert geom.frame_cycles == 312 * 63
     assert geom.content_first_raster == 51
     assert geom.content_height == 200
     assert geom.content_first_cycle == 14
     assert geom.content_cycles == 40
     assert geom.visible_sample_count == 8_000
+    assert geom.sample_index(50, 20) is None
+    assert geom.sample_index(51, 13) is None
     assert geom.sample_index(51, 14) == 0
     assert geom.sample_index(51, 53) == 39
-    assert geom.sample_index(250, 53) == 7_999
-    assert geom.sample_index(50, 14) is None
-    assert geom.sample_index(51, 13) is None
+    assert geom.sample_index(52, 14) == 40
+    assert geom.sample_index(250, 53) == 7999
     assert geom.sample_index(251, 14) is None
-    assert geom.sample_index(51, 54) is None
 
 
 def test_per_cycle_geometry_ntsc_frame_budget() -> None:
     geom = per_cycle_geometry("ntsc")
-
     assert geom.raster_lines == 263
     assert geom.cycles_per_line == 65
-    assert geom.frame_cycles == 263 * 65
     assert geom.visible_sample_count == 8_000
 
 
 def test_ensure_per_cycle_buffers_allocates_visible_sample_grid() -> None:
     mem = MemoryMap()
     mem.video_standard = "pal"
-
     mem.ensure_per_cycle_buffers()
-
-    assert mem.per_cycle_vic_samples is not None
-    assert mem.per_cycle_cia2_samples is not None
     assert mem.per_cycle_vic_flat is not None
     assert mem.per_cycle_cia2_flat is not None
-    assert len(mem.per_cycle_vic_samples) == 8_000
-    assert len(mem.per_cycle_cia2_samples) == 8_000
     assert len(mem.per_cycle_vic_flat) == 8_000 * 64
     assert len(mem.per_cycle_cia2_flat) == 8_000
     assert mem.per_cycle_snapshots_primed is False
@@ -55,42 +41,34 @@ def test_ensure_per_cycle_buffers_allocates_visible_sample_grid() -> None:
 
     mem.video_standard = "ntsc"
     mem.ensure_per_cycle_buffers()
-    assert mem.per_cycle_vic_flat is old_vic_flat
+    assert len(mem.per_cycle_vic_flat) == 8_000 * 64
+    assert per_cycle_geometry("ntsc").raster_lines == 263
 
 
 def test_prime_per_cycle_snapshots_from_current_vic() -> None:
     mem = MemoryMap()
+    mem.video_standard = "pal"
     mem.per_cycle_render_enabled = True
-    mem.poke_vic(0x11, 0x1B)
-    mem.poke_vic(0x18, 0x32)
     mem.cia2_pra = 0x7F
-
     mem.prime_per_cycle_snapshots_from_current_vic()
 
-    assert mem.per_cycle_vic_samples is not None
-    assert mem.per_cycle_cia2_samples is not None
     assert mem.per_cycle_vic_flat is not None
     assert mem.per_cycle_cia2_flat is not None
     assert mem.per_cycle_snapshots_primed is True
 
-    first = mem.per_cycle_vic_samples[0]
-    last = mem.per_cycle_vic_samples[-1]
-    assert first[0x11] == 0x1B
-    assert first[0x18] == 0x32
-    assert last == first
-    assert mem.per_cycle_cia2_samples[0] == 0x7F
-    assert mem.per_cycle_cia2_samples[-1] == 0x7F
-    assert mem.per_cycle_vic_flat[:64] == first
-    assert mem.per_cycle_vic_flat[-64:] == first
+    flat = mem.per_cycle_vic_flat
+    first = flat[0:64]
+    last = flat[-64:]
+    assert first == last
     assert mem.per_cycle_cia2_flat[0] == 0x7F
     assert mem.per_cycle_cia2_flat[-1] == 0x7F
 
 
 def test_prime_per_cycle_snapshots_is_gated() -> None:
     mem = MemoryMap()
-
+    mem.video_standard = "pal"
+    mem.per_cycle_render_enabled = False
     mem.prime_per_cycle_snapshots_from_current_vic()
 
-    assert mem.per_cycle_vic_samples is None
     assert mem.per_cycle_vic_flat is None
     assert mem.per_cycle_snapshots_primed is False

--- a/test/test_per_cycle_vic_buffers.py
+++ b/test/test_per_cycle_vic_buffers.py
@@ -1,0 +1,96 @@
+"""Per-cycle VIC buffer geometry and allocation foundation."""
+
+from c64py.memory import MemoryMap
+from c64py.video_beam import per_cycle_geometry
+
+
+def test_per_cycle_geometry_pal_visible_window() -> None:
+    geom = per_cycle_geometry("pal")
+
+    assert geom.raster_lines == 312
+    assert geom.cycles_per_line == 63
+    assert geom.frame_cycles == 312 * 63
+    assert geom.content_first_raster == 51
+    assert geom.content_height == 200
+    assert geom.content_first_cycle == 14
+    assert geom.content_cycles == 40
+    assert geom.visible_sample_count == 8_000
+    assert geom.sample_index(51, 14) == 0
+    assert geom.sample_index(51, 53) == 39
+    assert geom.sample_index(250, 53) == 7_999
+    assert geom.sample_index(50, 14) is None
+    assert geom.sample_index(51, 13) is None
+    assert geom.sample_index(251, 14) is None
+    assert geom.sample_index(51, 54) is None
+
+
+def test_per_cycle_geometry_ntsc_frame_budget() -> None:
+    geom = per_cycle_geometry("ntsc")
+
+    assert geom.raster_lines == 263
+    assert geom.cycles_per_line == 65
+    assert geom.frame_cycles == 263 * 65
+    assert geom.visible_sample_count == 8_000
+
+
+def test_ensure_per_cycle_buffers_allocates_visible_sample_grid() -> None:
+    mem = MemoryMap()
+    mem.video_standard = "pal"
+
+    mem.ensure_per_cycle_buffers()
+
+    assert mem.per_cycle_vic_samples is not None
+    assert mem.per_cycle_cia2_samples is not None
+    assert mem.per_cycle_vic_flat is not None
+    assert mem.per_cycle_cia2_flat is not None
+    assert len(mem.per_cycle_vic_samples) == 8_000
+    assert len(mem.per_cycle_cia2_samples) == 8_000
+    assert len(mem.per_cycle_vic_flat) == 8_000 * 64
+    assert len(mem.per_cycle_cia2_flat) == 8_000
+    assert mem.per_cycle_snapshots_primed is False
+
+    old_vic_flat = mem.per_cycle_vic_flat
+    mem.ensure_per_cycle_buffers()
+    assert mem.per_cycle_vic_flat is old_vic_flat
+
+    mem.video_standard = "ntsc"
+    mem.ensure_per_cycle_buffers()
+    assert mem.per_cycle_vic_flat is old_vic_flat
+
+
+def test_prime_per_cycle_snapshots_from_current_vic() -> None:
+    mem = MemoryMap()
+    mem.per_cycle_render_enabled = True
+    mem.poke_vic(0x11, 0x1B)
+    mem.poke_vic(0x18, 0x32)
+    mem.cia2_pra = 0x7F
+
+    mem.prime_per_cycle_snapshots_from_current_vic()
+
+    assert mem.per_cycle_vic_samples is not None
+    assert mem.per_cycle_cia2_samples is not None
+    assert mem.per_cycle_vic_flat is not None
+    assert mem.per_cycle_cia2_flat is not None
+    assert mem.per_cycle_snapshots_primed is True
+
+    first = mem.per_cycle_vic_samples[0]
+    last = mem.per_cycle_vic_samples[-1]
+    assert first[0x11] == 0x1B
+    assert first[0x18] == 0x32
+    assert last == first
+    assert mem.per_cycle_cia2_samples[0] == 0x7F
+    assert mem.per_cycle_cia2_samples[-1] == 0x7F
+    assert mem.per_cycle_vic_flat[:64] == first
+    assert mem.per_cycle_vic_flat[-64:] == first
+    assert mem.per_cycle_cia2_flat[0] == 0x7F
+    assert mem.per_cycle_cia2_flat[-1] == 0x7F
+
+
+def test_prime_per_cycle_snapshots_is_gated() -> None:
+    mem = MemoryMap()
+
+    mem.prime_per_cycle_snapshots_from_current_vic()
+
+    assert mem.per_cycle_vic_samples is None
+    assert mem.per_cycle_vic_flat is None
+    assert mem.per_cycle_snapshots_primed is False

--- a/test/test_per_cycle_vic_buffers.py
+++ b/test/test_per_cycle_vic_buffers.py
@@ -18,6 +18,11 @@ def test_per_cycle_geometry_pal_visible_window() -> None:
     assert geom.sample_index(251, 14) is None
 
 
+def test_per_cycle_geometry_normalizes_video_standard() -> None:
+    assert per_cycle_geometry("PAL").visible_sample_count == per_cycle_geometry("pal").visible_sample_count
+    assert per_cycle_geometry("Ntsc").raster_lines == 263
+
+
 def test_per_cycle_geometry_ntsc_frame_budget() -> None:
     geom = per_cycle_geometry("ntsc")
     assert geom.raster_lines == 263

--- a/test/test_per_cycle_vic_sampler.py
+++ b/test/test_per_cycle_vic_sampler.py
@@ -1,0 +1,71 @@
+"""Per-cycle VIC sampler (B2): visible-window capture after each VIC tick."""
+
+from __future__ import annotations
+
+from c64py.memory import MemoryMap
+from c64py.video_beam import per_cycle_geometry
+
+
+def test_per_cycle_capture_noop_when_disabled() -> None:
+    mem = MemoryMap()
+    mem.video_standard = "pal"
+    mem.per_cycle_render_enabled = False
+    mem.raster_line = 51
+    mem.raster_cycles = 14
+    mem.poke_vic(0x11, 0x1B)
+
+    mem.per_cycle_capture_vic_sample()
+
+    assert mem.per_cycle_vic_flat is None
+
+
+def test_per_cycle_capture_writes_visible_slots() -> None:
+    mem = MemoryMap()
+    mem.video_standard = "pal"
+    mem.per_cycle_render_enabled = True
+    mem.ensure_per_cycle_buffers()
+    geom = per_cycle_geometry("pal")
+
+    mem.poke_vic(0x11, 0x1B)
+    mem.poke_vic(0x18, 0x32)
+    mem.cia2_pra = 0xAA
+
+    for cy in range(geom.content_first_cycle, geom.content_first_cycle + geom.content_cycles):
+        mem.raster_line = geom.content_first_raster
+        mem.raster_cycles = cy
+        mem.per_cycle_capture_vic_sample()
+
+    assert mem.per_cycle_vic_samples is not None
+    for cy in range(geom.content_cycles):
+        snap = mem.per_cycle_vic_samples[cy]
+        assert snap[0x11] == 0x1B
+        assert snap[0x18] == 0x32
+        assert mem.per_cycle_cia2_samples[cy] == 0xAA
+
+
+def test_per_cycle_capture_mid_line_d011_diff() -> None:
+    """Two cycles on the same raster line see different $D011 shadow bytes."""
+    mem = MemoryMap()
+    mem.video_standard = "pal"
+    mem.per_cycle_render_enabled = True
+    mem.ensure_per_cycle_buffers()
+
+    line = 120
+    mem.raster_line = line
+    mem.raster_cycles = 14
+    mem.poke_vic(0x11, 0x1B)
+    mem.per_cycle_capture_vic_sample()
+
+    mem.raster_line = line
+    mem.raster_cycles = 15
+    mem.poke_vic(0x11, 0x5B)
+    mem.per_cycle_capture_vic_sample()
+
+    geom = per_cycle_geometry("pal")
+    i0 = geom.sample_index(line, 14)
+    i1 = geom.sample_index(line, 15)
+    assert i0 is not None and i1 is not None
+    assert mem.per_cycle_vic_samples is not None
+    assert mem.per_cycle_vic_samples[i0][0x11] == 0x1B
+    assert mem.per_cycle_vic_samples[i1][0x11] == 0x5B
+    assert mem.per_cycle_vic_samples[i0] != mem.per_cycle_vic_samples[i1]

--- a/test/test_per_cycle_vic_sampler.py
+++ b/test/test_per_cycle_vic_sampler.py
@@ -35,12 +35,15 @@ def test_per_cycle_capture_writes_visible_slots() -> None:
         mem.raster_cycles = cy
         mem.per_cycle_capture_vic_sample()
 
-    assert mem.per_cycle_vic_samples is not None
+    flat = mem.per_cycle_vic_flat
+    cia = mem.per_cycle_cia2_flat
+    assert flat is not None and cia is not None
     for cy in range(geom.content_cycles):
-        snap = mem.per_cycle_vic_samples[cy]
+        o = cy * 64
+        snap = flat[o : o + 64]
         assert snap[0x11] == 0x1B
         assert snap[0x18] == 0x32
-        assert mem.per_cycle_cia2_samples[cy] == 0xAA
+        assert cia[cy] == 0xAA
 
 
 def test_per_cycle_capture_mid_line_d011_diff() -> None:
@@ -65,7 +68,10 @@ def test_per_cycle_capture_mid_line_d011_diff() -> None:
     i0 = geom.sample_index(line, 14)
     i1 = geom.sample_index(line, 15)
     assert i0 is not None and i1 is not None
-    assert mem.per_cycle_vic_samples is not None
-    assert mem.per_cycle_vic_samples[i0][0x11] == 0x1B
-    assert mem.per_cycle_vic_samples[i1][0x11] == 0x5B
-    assert mem.per_cycle_vic_samples[i0] != mem.per_cycle_vic_samples[i1]
+    flat = mem.per_cycle_vic_flat
+    assert flat is not None
+    s0 = flat[i0 * 64 : (i0 + 1) * 64]
+    s1 = flat[i1 * 64 : (i1 + 1) * 64]
+    assert s0[0x11] == 0x1B
+    assert s1[0x11] == 0x5B
+    assert s0 != s1

--- a/test/test_presenter_rgb.py
+++ b/test/test_presenter_rgb.py
@@ -1,0 +1,10 @@
+"""Tests for :class:`c64py.presenter.RgbFrameBuffer` hot paths."""
+
+from c64py.presenter import RgbFrameBuffer
+
+
+def test_fill_rect_1x1_writes_packed_rgb() -> None:
+    fb = RgbFrameBuffer(4, 3)
+    fb.fill_rect(1, 2, 1, 1, (10, 20, 30))
+    i = (2 * 4 + 1) * 3
+    assert fb.buf[i : i + 3] == bytearray((10, 20, 30))

--- a/video_beam.py
+++ b/video_beam.py
@@ -7,13 +7,76 @@ These constants map host framebuffer rows to VIC raster lines for per-line snaps
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Optional
+
 # Approximate PAL visible window inside the full 312-line frame.
+PAL_RASTER_LINES = 312
+PAL_CYCLES_PER_LINE = 63
 PAL_CONTENT_FIRST_RASTER = 51
 PAL_CONTENT_HEIGHT = 200
 
 # NTSC reference (263 lines total).
+NTSC_RASTER_LINES = 263
+NTSC_CYCLES_PER_LINE = 65
 NTSC_CONTENT_FIRST_RASTER = 51
 NTSC_CONTENT_HEIGHT = 200
+
+# The VIC-II cycle engine uses 0-based raster cycles. Chip cycles 15..54 are
+# the 40 visible character fetch/display cycles for the 320-pixel content area.
+CONTENT_FIRST_RASTER_CYCLE = 14
+CONTENT_CYCLES = 40
+
+
+@dataclass(frozen=True)
+class VicPerCycleGeometry:
+    """Per-cycle sampler dimensions for one video standard."""
+
+    raster_lines: int
+    cycles_per_line: int
+    content_first_raster: int
+    content_height: int
+    content_first_cycle: int
+    content_cycles: int
+
+    @property
+    def frame_cycles(self) -> int:
+        return self.raster_lines * self.cycles_per_line
+
+    @property
+    def visible_sample_count(self) -> int:
+        return self.content_height * self.content_cycles
+
+    def sample_index(self, raster_line: int, raster_cycle: int) -> Optional[int]:
+        """Return visible-window sample index for a raster/cycle, or ``None`` outside it."""
+        y = int(raster_line) - self.content_first_raster
+        x = int(raster_cycle) - self.content_first_cycle
+        if 0 <= y < self.content_height and 0 <= x < self.content_cycles:
+            return y * self.content_cycles + x
+        return None
+
+
+PAL_PER_CYCLE_GEOMETRY = VicPerCycleGeometry(
+    raster_lines=PAL_RASTER_LINES,
+    cycles_per_line=PAL_CYCLES_PER_LINE,
+    content_first_raster=PAL_CONTENT_FIRST_RASTER,
+    content_height=PAL_CONTENT_HEIGHT,
+    content_first_cycle=CONTENT_FIRST_RASTER_CYCLE,
+    content_cycles=CONTENT_CYCLES,
+)
+NTSC_PER_CYCLE_GEOMETRY = VicPerCycleGeometry(
+    raster_lines=NTSC_RASTER_LINES,
+    cycles_per_line=NTSC_CYCLES_PER_LINE,
+    content_first_raster=NTSC_CONTENT_FIRST_RASTER,
+    content_height=NTSC_CONTENT_HEIGHT,
+    content_first_cycle=CONTENT_FIRST_RASTER_CYCLE,
+    content_cycles=CONTENT_CYCLES,
+)
+
+
+def per_cycle_geometry(video_standard: str) -> VicPerCycleGeometry:
+    """Return per-cycle sampler dimensions for ``video_standard``."""
+    return NTSC_PER_CYCLE_GEOMETRY if video_standard == "ntsc" else PAL_PER_CYCLE_GEOMETRY
 
 
 def content_row_to_raster_line(row: int, video_standard: str) -> int:

--- a/video_beam.py
+++ b/video_beam.py
@@ -74,14 +74,23 @@ NTSC_PER_CYCLE_GEOMETRY = VicPerCycleGeometry(
 )
 
 
+def _normalize_video_standard(video_standard: str) -> str:
+    v = (video_standard or "pal").strip().lower()
+    return "ntsc" if v == "ntsc" else "pal"
+
+
 def per_cycle_geometry(video_standard: str) -> VicPerCycleGeometry:
     """Return per-cycle sampler dimensions for ``video_standard``."""
-    return NTSC_PER_CYCLE_GEOMETRY if video_standard == "ntsc" else PAL_PER_CYCLE_GEOMETRY
+    return (
+        NTSC_PER_CYCLE_GEOMETRY
+        if _normalize_video_standard(video_standard) == "ntsc"
+        else PAL_PER_CYCLE_GEOMETRY
+    )
 
 
 def content_row_to_raster_line(row: int, video_standard: str) -> int:
     """Map a row index 0..199 inside the 320x200 content area to a raster line index."""
-    if video_standard == "ntsc":
+    if _normalize_video_standard(video_standard) == "ntsc":
         base = NTSC_CONTENT_FIRST_RASTER
         h = NTSC_CONTENT_HEIGHT
     else:


### PR DESCRIPTION
## Summary

Sync slice 5/6 from c64py-dev: per-cycle VIC buffers, sampler, bitmap scanline compositing, Rust per-cycle capture.

- 13 commits, 25 files, +2,144 / −159 lines (incremental)
- **Stacked on prior sync PRs** — merge after PRs #22–#25 land

## Key changes

- Per-cycle VIC buffers/sampler, bitmap scanline compositing
- Rust per-cycle capture in fast batch and native compositor
- `docs/per_cycle_vic.md`, presenter/graphics updates
- Tests: `test_per_cycle_*.py`, `test_presenter_rgb.py`

## Test plan

- [ ] CI passes
- [ ] Headless smoke test


Made with [Cursor](https://cursor.com)